### PR TITLE
Update disabling redis on-demand broker instructions

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -111,13 +111,17 @@ Operators should not downsize the VMs or disk size as this can cause data loss i
 
 If you want to remove the On-Demand Service from your tile, do the following: <br/>
 
+1. Navigate to the **Resource Config** page on the Redis for PCF tile. Set "Redis On-Demand Broker" job instances to 0.
+
 1. Navigate to the **Errands** page on the Redis for PCF tile. Set the following errands to 'off':
     * Register On-demand Redis Broker
     * On-demand Broker Smoke Tests
     * Upgrade all On-demand Redis Service Instances
     * Deregister On-demand Redis Broker
 
-1. Currently, to install Redis for PCF while turning off the on-demand service, the Operator must still configure at least one of the on-demand plans and create a service network. Instructions to create an empty service network are [here](https://discuss.pivotal.io/hc/en-us/articles/115010154387).
+1. The Operator must still create a service network. Instructions to create an empty service network are [here](https://discuss.pivotal.io/hc/en-us/articles/115010154387).
+
+1. The Operator may set all "Cache Plans" to "Plan Inactive".
 
 
 ###  <a id="shared-vm-config"></a>Shared-VM Plan


### PR DESCRIPTION
Users no longer need to specify cache plans and now can disable the provisioning of the vm altogether in resource config.

[#150894860]

Signed-off-by: Jack Newberry <jnewberry@pivotal.io>