### PR TITLE
[1.11] Redact example conf pass and config rename

### DIFF
--- a/redisconf.html.md.erb
+++ b/redisconf.html.md.erb
@@ -63,13 +63,13 @@ client-output-buffer-limit slave 256mb 64mb 60
 client-output-buffer-limit pubsub 32mb 8mb 60
 hz 10
 aof-rewrite-incremental-fsync yes
-rename-command CONFIG "L-P-Az5QXyt_-KvW5E7hVkK62t_p4Plo"
+rename-command CONFIG "<redacted>"
 rename-command SAVE "SAVE"
 rename-command BGSAVE "BGSAVE"
 rename-command DEBUG ""
 rename-command SHUTDOWN ""
 rename-command SLAVEOF ""
 rename-command SYNC ""
-requirepass 2f6b3cc5-4dce-427d-893f-0d7c5f6d2590
+requirepass <redacted>
 maxmemory 1775550873
 ```


### PR DESCRIPTION
1.11 version of https://github.com/pivotal-cf/docs-redis/pull/136

Remove unredacted example password and config alias, for https://www.pivotaltracker.com/story/show/156339118.

cc @terminatingcode