### PR TITLE
Add default redis.conf for on demand instance

### DIFF
--- a/redisconf.html.md.erb
+++ b/redisconf.html.md.erb
@@ -5,6 +5,54 @@ owner: London Services
 
 <strong><%= modified_date %></strong>
 
+The following is the default `redis.conf` file from a On-Demand plan instance:
+
+```
+daemonize yes
+pidfile /var/vcap/sys/run/redis.pid
+port 6379
+requirepass 1a1a2bb0-0ccc-222a-444b-1e1e1e1e2222
+
+# Logging
+logfile /var/vcap/sys/log/redis/redis.log
+syslog-enabled yes
+syslog-ident redis-server
+syslog-facility local0
+
+# Persistance
+dbfilename dump.rdb
+dir /var/vcap/store/redis
+appendonly no
+appendfilename appendonly.aof
+save 900 1
+save 300 10
+save 60 10000
+
+
+# Arbitrary Parameters
+maxmemory-policy allkeys-lru
+slowlog-log-slower-than 10000
+slowlog-max-len 128
+notify-keyspace-events ""
+
+# Plan Properties:
+timeout 3600s
+tcp-keepalive 60
+maxclients 10000
+rename-command EVAL "EVAL"
+rename-command EVALSHA "EVALSHA"
+
+# Command Masking
+rename-command CONFIG "A-B-Ab1AZec_-AaC1A2bAbB22a_a1Baa"
+rename-command SAVE "SAVE"
+rename-command BGSAVE "BGSAVE"
+rename-command DEBUG ""
+rename-command SHUTDOWN ""
+rename-command SLAVEOF ""
+rename-command SYNC ""
+maxmemory 1775550873
+```
+
 The following is a `redis.conf` file from a Dedicated-VM plan instance:
 
 ```


### PR DESCRIPTION
Apologies for the accidental push to master which we have reverted. This is to add the default redis.conf for on-demand redis instances so that operators and app developers can reference it.

For https://www.pivotaltracker.com/story/show/156339060

cc @ostenbom