### PR TITLE
Fixes to restore dedicated-vm plan docs

### DIFF
--- a/manual-br.html.md.erb
+++ b/manual-br.html.md.erb
@@ -329,6 +329,11 @@ this with `watch monit summary`
 ensure ownership and permissions are correct with
 `chown vcap:vcap /var/vcap/store/cf-redis-broker/statefile.json && chmod 660 /var/vcap/store/cf-redis-broker/statefile.json`
 
+1. Run `monit start all`
+
+1. Wait for monit services to enter the `running` state, you can watch
+this with `watch monit summary`
+
 1. Follow the instructions in [Restore a Redis for PCF Instance from a Backup](#restore) for your plan, to restore your backed up Redis data.
 
 1. Your Redis instance is now recovered.

--- a/manual-br.html.md.erb
+++ b/manual-br.html.md.erb
@@ -327,7 +327,7 @@ this with `watch monit summary`
 
 1. Copy the backed up `/var/vcap/store/cf-redis-broker/statefile.json` and
 ensure ownership and permissions are correct with
-`chown vcap:vcap /var/vcap/store/redis/dump.rdb && chmod 660 /var/vcap/store/redis/dump.rdb`
+`chown vcap:vcap /var/vcap/store/cf-redis-broker/statefile.json && chmod 660 /var/vcap/store/cf-redis-broker/statefile.json`
 
 1. Follow the instructions in [Restore a Redis for PCF Instance from a Backup](#restore) for your plan, to restore your backed up Redis data.
 


### PR DESCRIPTION
We found these corrections whilst restoring a Redis dedicated-vm instance and an on-demand instance as part of a full platform recovery on the BBR team.

@jamesjoshuahill and @alamages 

cc: @mrosecrance 