### PR TITLE
[1.11] Remove no-longer valid known limitations for on-demand automatic backups

### DIFF
--- a/architecture.html.md.erb
+++ b/architecture.html.md.erb
@@ -94,7 +94,6 @@ Limitations for the On-Demand Service include:
   (enabling Lua Scripting, max-clients, timeout, and TCP keep-alive),
   these settings are implemented in all instances already created.
 
-* Automatic backups are not available for on-demand plans.
 
 ## <a id ="lifecycle"></a>Lifecycle for On-Demand Service Plan
 


### PR DESCRIPTION
* automatic backups are available for on-demand plans for v1.11+

[#156723191]