### PR TITLE
Add known issue for automatic backups for On-Demand plans on v1.9

### DIFF
--- a/architecture.html.md.erb
+++ b/architecture.html.md.erb
@@ -92,11 +92,12 @@ Limitations for the on-demand service include:
 
 * If the operator updates the VM size, disk size, or the Redis configuration settings
   (enabling Lua Scripting, max-clients, timeout, and TCP keep-alive),
-  these settings are implemented in all instances already created. 
+  these settings are implemented in all instances already created.
+
+* Automatic backups are not available for on-demand plans.
 
 ## <a id ="lifecycle"></a>Lifecycle for On-Demand Service Plan
 
 The image below shows the lifecycle of Redis for PCF, from an operator installing the tile, through an app developer using the service, to an operator deleting the tile.
 
 ![On-Demand Lifecycle Diagram](Redis_timeline_demand.png)
-


### PR DESCRIPTION
This ensures operators are aware that automatic backups were not available for on-demand plans in v1.9

[#156723191]