### PR TITLE
Update references "On-Demand Redis" -> "Redis On-Demand"

### DIFF
--- a/bbr-backup.html.md.erb
+++ b/bbr-backup.html.md.erb
@@ -117,8 +117,8 @@ and can skip the restore for that artifact.
 
 ## <a id="inconsistancies"></a>Possible Inconsistent States
 
-Because the On-Demand Redis broker is not locked during the backup process,
-the backups of the PAS and service instances can be out of sync if an app developer creates or deletes an on-demand 
+Because the Redis On-Demand broker is not locked during the backup process,
+the backups of the PAS and service instances can be out of sync if an app developer creates or deletes an on-demand
 Redis service between the PAS backup and Redis service instance backups.
 
 ### <a id="no-restore-data"></a>No Backup Artifact for a Service Instance

--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -228,10 +228,10 @@ If you want to remove the On-Demand Service from your tile, do the following: <b
 1. Go to the **Resource Config** page on the Redis for PCF tile, and set the **Redis On-Demand Broker** job instances to 0.
 
 1. Navigate to the **Errands** page on the Redis for PCF tile, and set the following errands to **off**:
-    * Register On-demand Redis Broker
-    * On-demand Broker Smoke Tests
-    * Upgrade all On-demand Redis Service Instances
-    * Deregister On-demand Redis Broker
+    * Register On-Demand Broker
+    * On-Demand Broker Smoke Tests
+    * Upgrade All On-Demand Service Instances
+    * Delete All Service Instances and Deregister On-Demand Broker
 
 1. Create an empty service network.
    For instructions, see this [Knowledge Base article](https://discuss.pivotal.io/hc/en-us/articles/115010154387).

--- a/troubleshoot-instances.html.md.erb
+++ b/troubleshoot-instances.html.md.erb
@@ -5,7 +5,7 @@ owner: Redis
 
 <strong><%= modified_date %></strong>
 
-This topic provides basic instructions for app developers troubleshooting On-Demand Redis for Pivotal Cloud Foundry (PCF).
+This topic provides basic instructions for app developers troubleshooting Redis On-Demand for Pivotal Cloud Foundry (PCF).
 
 ## <a id="outages"></a>Temporary Outages
 

--- a/upgrade.html.md.erb
+++ b/upgrade.html.md.erb
@@ -153,7 +153,7 @@ When the operator applies any of the above changes to PAS (or Elastic Runtime), 
 after the operator runs the `upgrade-all-service-instances` BOSH errand, after all tile upgrades are completed successfully.
 
 * Any change to a field on the Redis for PCF tile causes BOSH to redeploy both the legacy
-and the On-Demand Redis Brokers after the operator runs the `upgrade-all-service-instances` errand.
+and the on-demand Redis Brokers after the operator runs the `upgrade-all-service-instances` errand.
 
 
 ## <a id="network-upgrades"></a> Network Changes after Deployment

--- a/using.html.md.erb
+++ b/using.html.md.erb
@@ -156,7 +156,7 @@ From within Pivotal Apps Manager, select **Marketplace** from the left navigatio
 
 #### On-Demand Service<br><br>
 
-1. Select **On-Demand Redis** from the displayed tiles in the Marketplace.<br><br>
+1. Select **Redis On-Demand** from the displayed tiles in the Marketplace.<br><br>
   ![marketplace_predis](predis_marketplace.png)
 
 1. Click on the appropriate **Select this plan** button to select the required **Redis Service Plan**.<br><br>


### PR DESCRIPTION
Also clean up some errand labels to be consistent.

For 1.13+ only, part of https://www.pivotaltracker.com/story/show/157187522