### PR TITLE
Update secure credentials to reflect removal of redis tile property

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -126,13 +126,6 @@ maximum number of Redis service instances that can be upgraded at the same time.
     Multiple Redis service instances will be concurrently unavailable during the upgrade.
   </p>
 
-1. (Optional) To secure your on-demand service instance credentials in runtime [CredHub](https://docs.pivotal.io/pivotalcf/credhub/) instead of the Cloud Controller Database (CCDB), perform the following steps:
-  1. Ensure that you have configured the Pivotal Application Service (PAS) tile to support securing service instance credentials in runtime CredHub. See [Step 1: Configure the PAS Tile](https://docs.pivotal.io/pivotalcf/opsguide/secure-si-creds.html#pas-config).
-  1. Select the checkbox to enable **Secure Service Instance Credentials with Runtime CredHub**.
-  1. Click **Save**.
-  1. After deploying the tile, notify developers that they must unbind and rebind existing service instances to secure their credentials with CredHub.
-    <p class="note"><strong>Note</strong>:
-    This is a beta feature. Use it at your own risk in non-production environments. Send comments and feedback to the <a href="mailto:pivotal-cf-feedback@pivotal.io">PCF Feedback List</a>.</p>
 
 1. To configure an on-demand plan, click **On-Demand Plan 1**, **2**, or **3**.</br></br>
 
@@ -218,6 +211,14 @@ maximum number of Redis service instances that can be upgraded at the same time.
     </table>
 
 1.  Click **Save**.
+
+#### <a id="secure-credentials"></a>(Optional) Enabling Secure Service Instance Credentials for On-Demand Redis
+
+To secure your on-demand service instance credentials in runtime [CredHub](https://docs.pivotal.io/pivotalcf/credhub/) instead of the Cloud Controller Database (CCDB), perform the following steps:
+  1. Configure the Pivotal Application Service (PAS) tile to support securing service instance credentials in runtime CredHub. See [Step 1: Configure the PAS Tile](https://docs.pivotal.io/pivotalcf/opsguide/secure-si-creds.html#pas-config).
+  1. After deploying the tile, notify developers that they must unbind and rebind existing service instances to secure their credentials with CredHub.
+    <p class="note"><strong>Note</strong>:
+    This is a beta feature. Use it at your own risk in non-production environments. Send comments and feedback to the <a href="mailto:pivotal-cf-feedback@pivotal.io">PCF Feedback List</a>.</p>
 
 #### <a id="change-on-demand"></a>Updating On-Demand Service Plans
 


### PR DESCRIPTION
Move to own section as setup now only involves the PAS tile.

Part of https://www.pivotaltracker.com/story/show/157657549

cc @dark5un 