### PR TITLE
Remove reference to wrong redis version

### DIFF
--- a/using.html.md.erb
+++ b/using.html.md.erb
@@ -362,7 +362,7 @@ Example `VCAP_SERVICES`
 
 ## <a id="logging"></a> Accessing Redis Metrics for On-Demand Service Instances(Beta)
 
-As of Redis for PCF v1.13+, the On-Demand service supports the Log Cache Loggregator feature that is enabled by default as of [PAS v2.2+](https://docs.pivotal.io/pivotalcf/2-2/pcf-release-notes/runtime-rn.html#log-cache).
+The Log Cache Loggregator feature that is enabled by default as of [PAS v2.2+](https://docs.pivotal.io/pivotalcf/2-2/pcf-release-notes/runtime-rn.html#log-cache).
 This enables app devs to tail metrics for On-Demand service instances.
 To install the CF CLI plugin run:
 ```


### PR DESCRIPTION
Fixes a documentation error which reference the wrong version of Redis this feature was introduced in.