### PR TITLE
Redis 1.12.2 release notes

### DIFF
--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -4,6 +4,81 @@ owner: London Services
 ---
 
 <strong><%= modified_date %></strong>
+## <a id="1122"></a> v1.12.2
+
+**Release Date: July 17, 2018**
+
+### Features
+
+* This release updates the packaged golang version to 1.10.3.
+
+### Fixes
+
+* AOF rewrite now occurs in the drain script for shared-vms. As part of this,
+the `BGREWRITEAOF` command has been aliased. This alias is available in the
+credentials tab on the tile.
+
+### Known Issues
+
+* The `redis-odb` service broker listens on port `12345`.
+This is inconsistent with other services.
+
+* The **When Changed** option for errands has unexpected behavior.
+Do not select this choice as an errand run-rule.
+For more information about this unexpected behavior, see
+[Errand Run Rules](https://docs.pivotal.io/tiledev/tile-errands.html#run-rules).
+
+<table border="1" class="nice">
+<tr>
+	  <th>Component</th>
+	  <th>Version</th>
+</tr>
+<tr>
+    <td>Stemcell</td>
+    <td>3468.51+</td>
+</tr>
+<tr>
+	<td>PCF<sup>*</sup></td>
+    <td>v2.0.x and v2.1.x</td>
+</tr>
+<tr>
+    <td>cf-redis-release</td>
+    <td>v434.0.10</td>
+</tr>
+<tr>
+    <td>on-demand-service-broker</td>
+    <td>v0.21.2</td>
+</tr>
+<tr>
+    <td>consul</td>
+    <td>v192.0.0</td>
+</tr>
+<tr>
+    <td>routing</td>
+    <td>v0.169.0</td>
+</tr>
+<tr>
+    <td>service-metrics</td>
+    <td>v1.5.11</td>
+</tr>
+<tr>
+    <td>service-backup</td>
+    <td>v18.1.9</td>
+</tr>
+<tr>
+    <td>syslog-migration</td>
+    <td>v10.0.0</td>
+</tr>
+<tr>
+    <td>loggregator</td>
+    <td>v101.3</td>
+</tr>
+<tr>
+    <td>Redis OSS</td>
+    <td>v4.0.8</td>
+</tr>
+
+</table>
 
 ## <a id="1121"></a> v1.12.1
 
@@ -36,6 +111,60 @@ For more information about this unexpected behavior, see
 [Errand Run Rules](https://docs.pivotal.io/tiledev/tile-errands.html#run-rules).
 
 * AOF rewrite does not occur in the drain script for shared-vms.
+
+### Compatibility
+
+<table border="1" class="nice">
+<tr>
+	  <th>Component</th>
+	  <th>Version</th>
+</tr>
+<tr>
+    <td>Stemcell</td>
+    <td>3468.42+</td>
+</tr>
+<tr>
+	<td>PCF<sup>*</sup></td>
+    <td>v2.0.x and v2.1.x</td>
+</tr>
+<tr>
+    <td>cf-redis-release</td>
+    <td>v434.0.6</td>
+</tr>
+<tr>
+    <td>on-demand-service-broker</td>
+    <td>v0.21.2</td>
+</tr>
+<tr>
+    <td>consul</td>
+    <td>v192.0.0</td>
+</tr>
+<tr>
+    <td>routing</td>
+    <td>v0.169.0</td>
+</tr>
+<tr>
+    <td>service-metrics</td>
+    <td>v1.5.11</td>
+</tr>
+<tr>
+    <td>service-backup</td>
+    <td>v18.1.9</td>
+</tr>
+<tr>
+    <td>syslog-migration</td>
+    <td>v10.0.0</td>
+</tr>
+<tr>
+    <td>loggregator</td>
+    <td>v101.3</td>
+</tr>
+<tr>
+    <td>Redis OSS</td>
+    <td>v4.0.8</td>
+</tr>
+
+</table>
 
 ## <a id="1120"></a> v1.12.0
 


### PR DESCRIPTION
Release notes for the patch release 1.12.2 which is currently in admin only mode in Pivnet.

Part of story: https://www.pivotaltracker.com/story/show/159005515

cc @ketchesonm 