### PR TITLE
Add usage documentation for shared-vm memory management

### DIFF
--- a/using.html.md.erb
+++ b/using.html.md.erb
@@ -364,6 +364,16 @@ Example `VCAP_SERVICES`
 
 3. In your app code, call the Redis service using the connection strings.
 
+### <a id="use-shared-vm"></a> Shared-VM instance usage
+
+Shared-VM plans provision Redis instances with a max-memory policy set to `no-eviction`. It is up the Application Developer to manage eviction of keys.
+
+There are a few options to do this:
+
+* Use [EXPIRE](https://redis.io/commands/expire) after setting keys or use [SETEX](https://redis.io/commands/setex) to set key value and expiry at the same time
+* Explicitly delete keys after the application is done using them
+* Add a lua script to delete keys after a set time period
+
 ## <a id="logging"></a> Access Redis Metrics for On-Demand Service Instances
 
 To access metrics for on-demand service instances, you can use Loggregator's Log 


### PR DESCRIPTION
- Inform App Devs of options for handling expiry.
- Lua scripting is always enabled for shared and dedicated plans

[#159559758]

Signed-off-by: Sarah Connor <sconnor@pivotal.io>