### PR TITLE
Add release notes to 1.13 specifying BBR support for On-Demand service

### DIFF
--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -24,6 +24,8 @@ This includes maximum parallel upgrades, number of canaries, and canary selectio
 
 * Updated the packaged golang version to 1.10.3.
 
+* On-Demand service instances can now be backed up and restored using the [BBR command-line tool](https://docs.pivotal.io/pivotalcf/2-2/customizing/backup-restore/index.html#bbr).
+
 ### Known Issues
 
 This release has the following issues:


### PR DESCRIPTION
Despite having extensive documentation on BBR support in the main docs, we missed the release notes.

Story here: https://www.pivotaltracker.com/story/show/159240842
