### PR TITLE
Add Restore to title of section

### DIFF
--- a/auto-backup.html.md.erb
+++ b/auto-backup.html.md.erb
@@ -116,7 +116,7 @@ Redis for PCF uses service account credentials to upload backups to Google Cloud
 For each backup destination, the field `Backup timeout` causes backups to fail after a configured timeout. 
 Redis' BGSAVE will continue but backups will not be uploaded to destinatons if this timeout is hit.
 
-## <a id="manual-br"></a>Manual Backups
+## <a id="manual-br"></a>Back Up and Restore Manually
 
 You may want to do a manual backup before doing a procedure that might cause data loss.
 For instructions, see the Knowledge Base article [Manually Backing Up and Restoring 


### PR DESCRIPTION
- The document has to do with both backup and restore and we don't metion restore anywhere else in the documentation