### PR TITLE
[1.12] Cleanup of Operators Troubleshooting

### DIFF
--- a/troubleshooting.html.md.erb
+++ b/troubleshooting.html.md.erb
@@ -9,7 +9,6 @@ In this topic:
 
 * [Useful Debugging Information](#debugging)
 * [About the Redis CLI](#redis-cli)
-* [How to Retrieve a Service Instance GUID](#guid)
 * [Troubleshooting Errors](#errors)
     * [Failed Install](#install-fail)
     * [Cannot Create or Delete Service Instances](#cannot-create-delete)
@@ -44,35 +43,94 @@ This topic lists troubleshooting information relevant to Redis for PCF.
 
 <a id="debugging"></a><h2> Useful Debugging Information</h2>
 
-If you encounter an issue, here is a list of useful information to gather,
-especially before you perform any destructive operations such as `cf purge-service-offerings`
-or `bosh -d SERVICE-INSTANCE-DEPLOYMENT delete-deployment`.
+<p class="note"><strong>Note</strong>:
+Some of the troubleshooting approaches suggest potentially destructive operations.
+It is recommended to backup both your Ops Manager and deployments before attempting such opperations.
+<br>
+<br>
+For more information on how to backup your setup and also how to export your Ops Manager installation,
+see <a href="https://docs.pivotal.io/pivotalcf/2-0/customizing/backup-restore/backup-pcf-bbr.html">Backing Up Pivotal Cloud Foundry with BBR</a>
+</p>
 
-Before debugging, ensure you know the following about your PCF deployment:
+### Before debugging, ensure you know the following about your PCF deployment:
 
-* The version of Redis for PCF
-
-* If upgrading, the previous of Redis for PCF
-
+* The version of Redis for PCF, and, if upgrading, the previous version of Redis for PCF
 * Ops Manager version, and, if upgrading, the previous version of Ops Manager
 
-* IaaS description
 
-### From Ops Manager:
-  * The installation logs
-  * A copy of all files in `/var/tempest/workspaces/default/deployments`
+### Useful Debugging Information:
+<a id="cf-cli"></a>Via the CF CLI:
+<table>
+  <tr>
+    <th>Purpose</th>
+    <th>Command</th>
+  </tr>
+  <tr>
+    <td>View the api endpoint, org and space</td>
+    <td><code>cf target</code></td>
+  </tr>
+  <tr>
+    <td>View the service offerings available in the targeted org and space</td>
+    <td><code>cf marketplace</code></td>
+  </tr>
+  <tr>
+    <td>View the apps deployed to the targeted org and space</td>
+    <td><code>cf apps</code></td>
+  </tr>
+  <tr>
+    <td>View the service instances deployed to the targeted org and space</td>
+    <td><code>cf services</code></td>
+  </tr>
+  <tr>
+    <td>View the GUID for a given service instance</td>
+    <td><code>cf service SERVICE_INSTANCE --guid</code></td>
+  </tr>
+  <tr>
+    <td>View the service instance or application logs</td>
+    <td><code>cf tail SERVICE_INSTANCE/APP</code></td>
+  </tr>
+</table>
+<br>
+<a id="bosh-cli"></a>Via the BOSH CLI:
+<table>
+  <tr>
+    <th>Purpose</th>
+    <th>Command</th>
+  </tr>
+  <tr>
+    <td>View the targeted BOSH director, version and CPI</td>
+    <td><code>bosh env</code></td>
+  </tr>
+  <tr>
+    <td>View the deployments deployed via the targeted BOSH director</td>
+    <td><code>bosh deployments</code></td>
+  </tr>
+  <tr>
+    <td>View the vms for a given deployment</td>
+    <td><code>bosh -d DEPLOYMENT vms</code></td>
+  </tr>
+  <tr>
+    <td>Ssh onto a given deployment's vm</td>
+    <td><code>bosh -d DEPLOYMENT ssh VM</code></td>
+  </tr>
+</table>
 
-### For All VMs, Unless Specified Otherwise:
-  * Copy of `/var/vcap/sys/log` (particularly the broker)
-  * If unable to get logs from disk, logs from a forwarded endpoint
-  * `monit summary`
-  * Full `ps aux`: Has monit done its job?
-  * `ps aux | grep redis-serve[r]`: Are Redis instances running?
+
+Additional information can be obtained once ssh'ed onto a broker or service instance:
+
+  * System logs can be located in `/var/vcap/sys/log`.
+  * Process health can be checked by `sudo monit summary`.
+  * A list of all processes can be obtained by `ps aux`.
   * `df -h`: disk usage
   * `free -m`: memory usage
-  * `cf m`
-  * `tree /var/vcap/store/cf-redis-broker/redis-data` (broker only)
-  * Copy of `/var/vcap/store/cf-redis-broker/statefile.json` (broker only)
+
+
+Specific to the cf-redis broker:
+
+  * For shared-vms, the redis processes are collocated with the CF-Redis broker and can be checked using `ps aux | grep redis-server`.
+  * Shared-vm data is stored in `/var/vcap/store/cf-redis-broker/redis-data`.
+  * A map of dedicated-vms can be found at `/var/vcap/store/cf-redis-broker/statefile.json`.
+
 
 <a id="redis-cli"></a><h2>About the Redis CLI</h2>
 
@@ -102,10 +160,6 @@ to retrieve the password and port number for the service instance.
     For more information about the redis-cli interactive mode, see
     [Interactive Mode](https://redis.io/topics/rediscli#interactive-mode) in the
     Redis documentation.
-
-<a id="guid"></a><h2>How to Retrieve a Service Instance GUID</h2>
-
-<%= partial '../../redis/odb/retrieve-guid' %>
 
 
 <a id="errors"><h2></a>Troubleshooting Errors</h2>

--- a/troubleshooting.html.md.erb
+++ b/troubleshooting.html.md.erb
@@ -38,7 +38,6 @@ In this topic:
     * [Identify Service Instance Owner](#id-instance-owner)
     * [Monitor Quota Saturation and Service Instance Count](#monitor-quota)
 * [Knowledge Base Articles](#Knowledge)
-* [Other Issues](#other)
 
 
 This topic lists troubleshooting information relevant to Redis for PCF.
@@ -183,7 +182,8 @@ The disk might be full.
 For a short-term solution, do the following:<br><br>
 
 <ol>
-  <li>SSH into the affected Redis instance.</li>
+  <li><a href="#bosh-cli">SSH</a> into the affected Redis instance.</li>
+  <li>Log into the <a href="#redis-cli">redis-cli</a>.</li>
   <li>Run <code>redis-cli CONFIG SET appendonly no</code> to disable AOF persistence.</li>
   <li>Delete the <code>/var/vcap/store/redis/appendonly.aof</code> file.</li>
   <li>Run <code>kill -HUP REDIS-SERVER-PID</code> to restart the Redis process.</li>
@@ -213,9 +213,17 @@ or if the Redis AOF uses all the disk space.
 
 <strong>Solution</strong><br>
 
-Configure the disk to at least 1.5 times the RAM.
-Otherwise, if the AOF is using all the disk space, see <a href="#disk-full">Redis server is unable to append to the AOF</a>.
-
+<ol>
+  <li>Ensure the disk is configured to at least 1.5 times the RAM.</li>
+  <li>Check if the AOF is using too much disk space by doing the following:
+    <ol>
+      <li>BOSH <a href="#bosh-cli">SSH</a> into the affected service instance VM.</li><br>
+      <li>Run <code>cd /var/vcap/store/redis; ls -la</code> to list the size of each file.</li><br>
+      <li>If the <code>appendonly.aof</code> file is large, follow the instuctions
+        in <a href="#disk-full">AOF Write or Rewrite Errors</a>.</li>
+    </ol>
+  </li>
+</ol>
 
 
 <a id="redis-client-errors"></a><h3>Error Messages from the Redis Client</h3>
@@ -335,7 +343,7 @@ Orphaned instances can occur in the following situations:
 
 <a id="components"></a><h2>Troubleshooting Components</h2>
 
-Guidance on checking for and fixing issues in on-demand service components.
+Guidance on checking for and fixing issues in cf-redis and on-demand service components.
 
 <a id="bosh"></a><h3>BOSH Problems</h3>
 
@@ -387,7 +395,9 @@ Guidance on checking for and fixing issues in on-demand service components.
 
 <a id="techniques"></a><h2>Techniques for Troubleshooting</h2>
 
-This section contains instructions on interacting with the on-demand service broker and on-demand service instance BOSH deployments, and on performing general maintenance and housekeeping tasks.
+This section contains instructions on interacting with the on-demand service broker
+and on-demand service instance BOSH deployments, and on performing general maintenance
+and housekeeping tasks.
 
 <a id="parse-error"></a><h3>Parse a Cloud Foundry (CF) Error Message</h3>
 
@@ -470,39 +480,3 @@ The following are <a href="https://discuss.pivotal.io/hc/en-us/sections/20021530
   <li><a href="https://pvtl.force.com/s/article/Removing-dedicated-vm-Service-Instances-from-the-CF-when-deleted-from-BOSH"> Removing dedicated-VM service instances on CF when already deleted from BOSH</a></li>
   <li><a href="https://pvtl.force.com/s/article/Migrating-from-dedicated-vm-service-plans-to-on-demand-service-plans">Migrating from dedicated-VM service plans to on-demand service plans</a></li>
 </ul>
-
-
-<a id="other"></a><h2>Other Issues</h2>
-
-
-<table border='1' class='nice'>
-<tr>
-  <th width="22%">Error</th>
-  <td><code>Failed to target Cloud Foundry</code>
-  </td>
-</tr>
-<tr>
-  <th>Cause</th>
-  <td>Your Pivotal Cloud Foundry is unresponsive</td>
-</tr>
-<tr>
-  <th>Solution</th>
-  <td>Examine the detailed error message in the logs and check the <a href="https://docs.pivotal.io/pivotalcf/1-7/customizing/troubleshooting.html">PCF Troubleshooting Guide</a> for advice</td>
-</tr>
-</table>
-
-<table border='1' class='nice'>
-<tr>
-  <th width="22%">Error</th>
-  <td><code>Failed to bind Redis service instance to test app</code>
-  </td>
-</tr>
-<tr>
-  <th>Cause</th>
-  <td>Your deployment's broker has not been registered with Pivotal Cloud Foundry</td>
-</tr>
-<tr>
-  <th>Solution</th>
-  <td>Examine the broker-registrar installation step output and troubleshoot any problems.</td>
-</tr>
-</table>


### PR DESCRIPTION
Story here: https://www.pivotaltracker.com/story/show/160345463

Notable changes include:
- re-writing the useful debugging section
- updating troubleshooting errors section to have more clarity
- removed redundant others section (one was too general, the other wrong)

Related: https://github.com/pivotal-cf/docs-on-demand-service-broker/pull/66