### PR TITLE
[1.11] Cleanup of Operators Troubleshooting

### DIFF
--- a/troubleshooting.html.md.erb
+++ b/troubleshooting.html.md.erb
@@ -9,7 +9,6 @@ In this topic:
 
 * [Useful Debugging Information](#debugging)
 * [About the Redis CLI](#redis-cli)
-* [How to Retrieve a Service Instance GUID](#guid)
 * [Troubleshooting Errors](#errors)
     * [Failed Install](#install-fail)
     * [Cannot Create or Delete Service Instances](#cannot-create-delete)
@@ -43,35 +42,94 @@ This topic lists troubleshooting information relevant to Redis for PCF.
 
 <a id="debugging"></a><h2> Useful Debugging Information</h2>
 
-If you encounter an issue, here is a list of useful information to gather,
-especially before you perform any destructive operations such as `cf purge-service-offerings`
-or `bosh -d SERVICE-INSTANCE-DEPLOYMENT delete-deployment`.
+<p class="note"><strong>Note</strong>:
+Some of the troubleshooting approaches suggest potentially destructive operations.
+It is recommended to backup both your Ops Manager and deployments before attempting such opperations.
+<br>
+<br>
+For more information on how to backup your setup and also how to export your Ops Manager installation,
+see <a href="https://docs.pivotal.io/pivotalcf/2-0/customizing/backup-restore/backup-pcf-bbr.html">Backing Up Pivotal Cloud Foundry with BBR</a>
+</p>
 
-Before debugging, ensure you know the following about your PCF deployment:
+### Before debugging, ensure you know the following about your PCF deployment:
 
-* The version of Redis for PCF
-
-* If upgrading, the previous of Redis for PCF
-
+* The version of Redis for PCF, and, if upgrading, the previous version of Redis for PCF
 * Ops Manager version, and, if upgrading, the previous version of Ops Manager
 
-* IaaS description
 
-### From Ops Manager:
-  * The installation logs
-  * A copy of all files in `/var/tempest/workspaces/default/deployments`
+### Useful Debugging Information:
+<a id="cf-cli"></a>Via the CF CLI:
+<table>
+  <tr>
+    <th>Purpose</th>
+    <th>Command</th>
+  </tr>
+  <tr>
+    <td>View the api endpoint, org and space</td>
+    <td><code>cf target</code></td>
+  </tr>
+  <tr>
+    <td>View the service offerings available in the targeted org and space</td>
+    <td><code>cf marketplace</code></td>
+  </tr>
+  <tr>
+    <td>View the apps deployed to the targeted org and space</td>
+    <td><code>cf apps</code></td>
+  </tr>
+  <tr>
+    <td>View the service instances deployed to the targeted org and space</td>
+    <td><code>cf services</code></td>
+  </tr>
+  <tr>
+    <td>View the GUID for a given service instance</td>
+    <td><code>cf service SERVICE_INSTANCE --guid</code></td>
+  </tr>
+  <tr>
+    <td>View the service instance or application logs</td>
+    <td><code>cf tail SERVICE_INSTANCE/APP</code></td>
+  </tr>
+</table>
+<br>
+<a id="bosh-cli"></a>Via the BOSH CLI:
+<table>
+  <tr>
+    <th>Purpose</th>
+    <th>Command</th>
+  </tr>
+  <tr>
+    <td>View the targeted BOSH director, version and CPI</td>
+    <td><code>bosh env</code></td>
+  </tr>
+  <tr>
+    <td>View the deployments deployed via the targeted BOSH director</td>
+    <td><code>bosh deployments</code></td>
+  </tr>
+  <tr>
+    <td>View the vms for a given deployment</td>
+    <td><code>bosh -d DEPLOYMENT vms</code></td>
+  </tr>
+  <tr>
+    <td>Ssh onto a given deployment's vm</td>
+    <td><code>bosh -d DEPLOYMENT ssh VM</code></td>
+  </tr>
+</table>
 
-### For All VMs, Unless Specified Otherwise:
-  * Copy of `/var/vcap/sys/log` (particularly the broker)
-  * If unable to get logs from disk, logs from a forwarded endpoint
-  * `monit summary`
-  * Full `ps aux`: Has monit done its job?
-  * `ps aux | grep redis-serve[r]`: Are Redis instances running?
+
+Additional information can be obtained once ssh'ed onto a broker or service instance:
+
+  * System logs can be located in `/var/vcap/sys/log`.
+  * Process health can be checked by `sudo monit summary`.
+  * A list of all processes can be obtained by `ps aux`.
   * `df -h`: disk usage
   * `free -m`: memory usage
-  * `cf m`
-  * `tree /var/vcap/store/cf-redis-broker/redis-data` (broker only)
-  * Copy of `/var/vcap/store/cf-redis-broker/statefile.json` (broker only)
+
+
+Specific to the cf-redis broker:
+
+  * For shared-vms, the redis processes are collocated with the CF-Redis broker and can be checked using `ps aux | grep redis-server`.
+  * Shared-vm data is stored in `/var/vcap/store/cf-redis-broker/redis-data`.
+  * A map of dedicated-vms can be found at `/var/vcap/store/cf-redis-broker/statefile.json`.
+
 
 <a id="redis-cli"></a><h2>About the Redis CLI</h2>
 
@@ -101,10 +159,6 @@ to retrieve the password and port number for the service instance.
     For more information about the redis-cli interactive mode, see
     [Interactive Mode](https://redis.io/topics/rediscli#interactive-mode) in the
     Redis documentation.
-
-<a id="guid"></a><h2>How to Retrieve a Service Instance GUID</h2>
-
-<%= partial '../../redis/odb/retrieve-guid' %>
 
 
 <a id="errors"><h2></a>Troubleshooting Errors</h2>

--- a/troubleshooting.html.md.erb
+++ b/troubleshooting.html.md.erb
@@ -35,7 +35,6 @@ In this topic:
     * [Identify Service Instance Owner](#id-instance-owner)
     * [Monitor Quota Saturation and Service Instance Count](#monitor-quota)
 * [Knowledge Base Articles](#Knowledge)
-* [Other Issues](#other)
 
 
 This topic lists troubleshooting information relevant to Redis for PCF.
@@ -199,6 +198,106 @@ Start here if you are responding to a specific error or error messages.
 
 <%= partial '../../redis/odb/tshoot-err-missing-logs' %>
 
+<a id="syslog-errors"></a><h3>Error Messages Logged in Syslog</h3>
+
+You can configure Redis for PCF with remote syslog forwarding.
+For more information, see <a href="installing.html#syslog">Configure Syslog Forwarding</a>.
+
+<br><br>
+
+This section helps to troubleshoot the following errors logged in syslog:
+<br><br>
+<ul>
+  <li><a href="#disk-full">AOF Write or Rewrite Errors</a></li>
+  <li><a href="#disk-size">Saving Error</a></li>
+</ul>
+
+<a id="disk-full"></a><h4>AOF Write or Rewrite Errors</h4>
+<br>
+<strong>Symptom</strong><br><br>
+
+One of the following error messages is logged:<br>
+
+<pre class="terminal">Short write while writing to the AOF file</pre>
+<pre class="terminal">Opening the temp file for AOF rewrite in rewriteAppendOnlyFile(): No space left on device</pre>
+<pre class="terminal">Background AOF rewrite terminated with error</pre>
+<br>
+
+<strong>Explanation</strong><br><br>
+
+This is logged when the Redis server is unable to append to the Redis append-only file (AOF).
+The disk might be full.
+<br><br>
+
+<strong>Solution</strong><br><br>
+
+For a short-term solution, do the following:<br><br>
+
+<ol>
+  <li><a href="#bosh-cli">SSH</a> into the affected Redis instance.</li>
+  <li>Log into the <a href="#redis-cli">redis-cli</a>.</li>
+  <li>Run <code>redis-cli CONFIG SET appendonly no</code> to disable AOF persistence.</li>
+  <li>Delete the <code>/var/vcap/store/redis/appendonly.aof</code> file.</li>
+  <li>Run <code>kill -HUP REDIS-SERVER-PID</code> to restart the Redis process.</li>
+  <li>Run <code>redis-cli CONFIG SET appendonly yes</code> to re-enable AOF persistence.</li>
+</ol>
+
+For a long-term solution, upgrade to Redis for PCF v1.12 or later.
+In older versions of the Redis for PCF tile, AOF persistence is enabled by default.
+Upgrading to the latest version of the tile disables AOF persistence.
+
+
+<a id="disk-size"></a><h4>Saving Error</h4><br>
+
+<strong>Symptom</strong><br><br>
+
+One of the following error messages is logged:<br>
+
+<pre class="terminal">Background saving error</pre>
+<pre class="terminal">Failed opening the RDB file dump.rdb (in server root dir /var/vcap/store/redis) for saving: No space left on device</pre>
+<br>
+
+<strong>Explanation</strong><br><br>
+
+This might be logged when the configured disk size is too small,
+or if the Redis AOF uses all the disk space.
+<br><br>
+
+<strong>Solution</strong><br><br>
+
+To prevent this error, do the following:
+
+<ol>
+  <li>Ensure the disk is configured to at least 1.5 times the RAM.</li>
+  <li>Check if the AOF is using too much disk space by doing the following:
+    <ol>
+      <li>BOSH <a href="#bosh-cli">SSH</a> into the affected service instance VM.</li><br>
+      <li>Run <code>cd /var/vcap/store/redis; ls -la</code> to list the size of each file.</li><br>
+      <li>If the <code>appendonly.aof</code> file is large, follow the instuctions
+        in <a href="#disk-full">AOF Write or Rewrite Errors</a>.</li>
+    </ol>
+  </li>
+</ol>
+
+
+<a id="backup-errors"></a><h3>Failed Backup</h3><br>
+
+<strong>Symptom</strong><br><br>
+
+The following error message is logged:<br>
+<pre class="terminal">Backup has failed. Redis must be running for a backup to run</pre>
+<br>
+
+<strong>Explanation</strong><br><br>
+
+This is logged if a backup is initiated against a Redis server that is down.
+<br><br>
+
+<strong>Solution</strong><br><br>
+Ensure that the Redis server being backed up is running.
+To do this, run <code>bosh restart</code> against the affected service instance VM.
+
+
 <a id="orphaned-instances"></a><h3>Orphaned Instances</h3><br>
 
 <strong>Symptom</strong><br><br>
@@ -240,7 +339,7 @@ Orphaned instances can occur in the following situations:
 
 <a id="components"></a><h2>Troubleshooting Components</h2>
 
-Guidance on checking for and fixing issues in on-demand service components.
+Guidance on checking for and fixing issues in cf-redis and on-demand service components.
 
 <a id="bosh"></a><h3>BOSH Problems</h3>
 
@@ -292,7 +391,9 @@ Guidance on checking for and fixing issues in on-demand service components.
 
 <a id="techniques"></a><h2>Techniques for Troubleshooting</h2>
 
-This section contains instructions on interacting with the on-demand service broker and on-demand service instance BOSH deployments, and on performing general maintenance and housekeeping tasks.
+This section contains instructions on interacting with the on-demand service broker
+and on-demand service instance BOSH deployments, and on performing general maintenance
+and housekeeping tasks.
 
 <a id="parse-error"></a><h3>Parse a Cloud Foundry (CF) Error Message</h3>
 
@@ -375,39 +476,3 @@ The following are <a href="https://discuss.pivotal.io/hc/en-us/sections/20021530
   <li><a href="https://pvtl.force.com/s/article/Removing-dedicated-vm-Service-Instances-from-the-CF-when-deleted-from-BOSH"> Removing dedicated-VM service instances on CF when already deleted from BOSH</a></li>
   <li><a href="https://pvtl.force.com/s/article/Migrating-from-dedicated-vm-service-plans-to-on-demand-service-plans">Migrating from dedicated-VM service plans to on-demand service plans</a></li>
 </ul>
-
-
-<a id="other"></a><h2>Other Issues</h2>
-
-
-<table border='1' class='nice'>
-<tr>
-  <th width="22%">Error</th>
-  <td><code>Failed to target Cloud Foundry</code>
-  </td>
-</tr>
-<tr>
-  <th>Cause</th>
-  <td>Your Pivotal Cloud Foundry is unresponsive</td>
-</tr>
-<tr>
-  <th>Solution</th>
-  <td>Examine the detailed error message in the logs and check the <a href="https://docs.pivotal.io/pivotalcf/1-7/customizing/troubleshooting.html">PCF Troubleshooting Guide</a> for advice</td>
-</tr>
-</table>
-
-<table border='1' class='nice'>
-<tr>
-  <th width="22%">Error</th>
-  <td><code>Failed to bind Redis service instance to test app</code>
-  </td>
-</tr>
-<tr>
-  <th>Cause</th>
-  <td>Your deployment's broker has not been registered with Pivotal Cloud Foundry</td>
-</tr>
-<tr>
-  <th>Solution</th>
-  <td>Examine the broker-registrar installation step output and troubleshoot any problems.</td>
-</tr>
-</table>


### PR DESCRIPTION
**Note:** I pulled in the partials on this version as they were missing in the 1.11 version of this page but they are still applicable and I see no conflicts in information with the 1.11 tile version.

Story here: https://www.pivotaltracker.com/story/show/160345463

Notable changes include:
- re-writing the useful debugging section
- updating troubleshooting errors section to have more clarity
- removed redundant others section (one was too general, the other wrong)

Related: https://github.com/pivotal-cf/docs-on-demand-service-broker/pull/66