### PR TITLE
[1.14] App troubleshooting docs touchup

### DIFF
--- a/troubleshoot-instances.html.md.erb
+++ b/troubleshoot-instances.html.md.erb
@@ -7,6 +7,38 @@ owner: Redis
 
 This topic provides basic instructions for app developers troubleshooting Redis On-Demand for Pivotal Cloud Foundry (PCF).
 
+## <a id="debugging"></a>Debugging Via the CF CLI
+
+### cf CLI Commands
+
+<table>
+  <tr>
+    <th>Purpose</th>
+    <th>Command</th>
+  </tr>
+  <tr>
+    <td>View the API endpoint, org, and space</td>
+    <td><code>cf target</code></td>
+  </tr>
+  <tr>
+    <td>View the service offerings available in the targeted org and space</td>
+    <td><code>cf marketplace</code></td>
+  </tr>
+  <tr>
+    <td>View the apps deployed to the targeted org and space</td>
+    <td><code>cf apps</code></td>
+  </tr>
+  <tr>
+    <td>View the service instances deployed to the targeted org and space</td>
+    <td><code>cf services</code></td>
+  </tr>
+  <tr>
+    <td>View the GUID for a given service instance</td>
+    <td><code>cf service SERVICE_INSTANCE --guid</code></td>
+  </tr>
+</table>
+<br>
+
 ## <a id="outages"></a>Temporary Outages
 
 Redis for PCF service instances can become temporarily inaccessible during upgrades and VM or network failures.
@@ -37,8 +69,8 @@ You may see an error when using the Cloud Foundry Command-Line Interface (cf CLI
     $ cf services
     Getting services in org my-org / space my-space as user<span>@</span>example.com...
     OK
-    name          service      plan        bound apps    last operation
-    my-instance   p.Redis      db-small                  create succeeded
+    name          service      plan           bound apps    last operation
+    my-instance   p.redis      cache-small                  create succeeded
     </pre>
 
 1. Run `cf service SERVICE-INSTANCE-NAME` to retrieve more information about a specific instance.
@@ -129,7 +161,7 @@ This might occur when the Redis server's disk is full.
 <strong>Solution</strong><br>
 
 A more informative message might be logged in the syslog.
-For more information, see <a href="#syslog-errors">Syslog Errors</a>.
+For more information, see <a href="./troubleshooting.html#syslog-errors">Syslog Errors</a>.
 
 ## <a id="kb"></a>Knowledge Base (Community)
 

--- a/troubleshoot-instances.html.md.erb
+++ b/troubleshoot-instances.html.md.erb
@@ -97,7 +97,7 @@ For instructions on how to retrieve the password, see [Retrieve the Password for
 ## <a id="redis-client-errors"></a>Error Messages from the Redis Client
 
 Certain errors are returned to the Redis client instead of being recorded in the logs.
-The Redis protocol represents errors as simple strings beginning with a '-' character. <br><br>
+The Redis protocol represents errors as simple strings beginning with a `-` character. <br><br>
 
 This section helps to troubleshoot the following errors:
 <br><br>
@@ -168,6 +168,25 @@ This might occur when the Redis server's disk is full.
 
 A more informative message might be logged in the syslog.
 For more information, see <a href="./troubleshooting.html#syslog-errors">Syslog Errors</a>.
+
+### <a id="err"></a>Unknown Command Error
+
+<strong>Symptom</strong><br>
+
+You receive the following error message when running <code>redis-cli COMMAND</code>
+or issuing the a command using another Redis client:
+
+<pre class="terminal">-ERR unknown command</pre>
+<br>
+
+<strong>Explanation</strong><br>
+
+For security reasons, certain commands such as `CONFIG`, `SAVE`, and `BGSAVE` are not available by default.
+<br><br>
+
+<strong>Solution</strong><br>
+
+Talk to your operator about the availability of a command.
 
 ## <a id="kb"></a>Knowledge Base (Community)
 

--- a/troubleshoot-instances.html.md.erb
+++ b/troubleshoot-instances.html.md.erb
@@ -36,6 +36,10 @@ This topic provides basic instructions for app developers troubleshooting Redis 
     <td>View the GUID for a given service instance</td>
     <td><code>cf service SERVICE_INSTANCE --guid</code></td>
   </tr>
+  <tr>
+    <td>View the service instance or application logs</td>
+    <td><code>cf tail SERVICE_INSTANCE/APP</code></td>
+  </tr>
 </table>
 <br>
 
@@ -76,6 +80,8 @@ You may see an error when using the Cloud Foundry Command-Line Interface (cf CLI
 1. Run `cf service SERVICE-INSTANCE-NAME` to retrieve more information about a specific instance.
 
 1. Run `cf service SERVICE-INSTANCE-NAME --guid` to retrieve the GUID of the instance, which is useful for debugging.
+
+1. Run `cf tail SERVICE-INSTANCE-NAME/APP-NAME` to retrieve service instance of app logs if the <a href="using.html#logging">Log Cache CLI plugin</a> is enabled (only available in Redis for PCF 1.14+)
 
 ### <a id="instance-credentials"></a> Retrieve the Password for a Redis Service Instance
 


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/160616161

- added debugging cf cli commands,
- fixed broken link to syslog errors (line 170)
- added explanation on intentionally unavailable Redis commands