### PR TITLE
[1.11] Removed Log Cache Ref

### DIFF
--- a/troubleshooting.html.md.erb
+++ b/troubleshooting.html.md.erb
@@ -85,10 +85,6 @@ Before debugging, gather the following about your PCF deployment:
     <td>View the GUID for a given service instance</td>
     <td><code>cf service SERVICE_INSTANCE --guid</code></td>
   </tr>
-  <tr>
-    <td>View the service instance or application logs</td>
-    <td><code>cf tail SERVICE_INSTANCE/APP</code></td>
-  </tr>
 </table>
 <br>
 


### PR DESCRIPTION
For: https://www.pivotaltracker.com/story/show/160755897

A previous re-write backported references to the cf tail command which is only available in Redis 1.14+