### PR TITLE
[1.14] Rename 1.15 to 2.0. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Redis for PCF Docs
 
-**IMPORTANT:** The **1.14** branch is not yet released, and the **master** branch is for 1.15. Therefore, the edge pipeline publishes both
-1.14 and 1.15 docs. When 1.14 releases, it will be moved to the production pipeline.
+**IMPORTANT:** The **1.14** branch is not yet released, and the **master** branch is for 2.0 (previously known as 1.15). Therefore, the edge pipeline publishes both
+1.14 and 2.0 docs. When 1.14 releases, it will be moved to the production pipeline.
 
 
 ## Where is the book repo?

--- a/appdevs.html.md.erb
+++ b/appdevs.html.md.erb
@@ -33,7 +33,7 @@ Redis for PCF v1.8+ offers On-Demand, Dedicated-VM, and Shared-VM services.
 
 <p class="note"><strong>Note</strong>: As of Redis for PCF v1.11,
     the on-demand service is at feature parity with the dedicated-VM service.
-    The dedicated-VM service plan will be deprecated.
+    The dedicated-VM service plan will be deprecated and completely removed in v2.0.
     Pivotal recommends using the on-demand service plan.</p>
 
 For more information on the plans, see the service offerings for the [on-demand plan](./architecture.html) and the [dedicated and shared plans](./architecture-pp.html).

--- a/architecture-pp.html.md.erb
+++ b/architecture-pp.html.md.erb
@@ -11,7 +11,7 @@ For similar information for the On-Demand service plan, see [On-Demand Service O
 
 <p class="note"><strong>Note</strong>: As of Redis for PCF v1.11,
     the on-demand service is at feature parity with the dedicated-VM service.
-    The dedicated-VM service plan will be deprecated.
+    The dedicated-VM service plan will be deprecated and completely removed in v2.0.
     Pivotal recommends using the on-demand service plan.</p>
 
 ## <a id="about"></a> About the Pre-Provisioned Plans

--- a/architecture.html.md.erb
+++ b/architecture.html.md.erb
@@ -8,6 +8,7 @@ owner: London Services
 Redis for PCF offers On-Demand, Dedicated-VM, and Shared-VM service plans.
 This section describes the architecture, lifecycle, and configurations of the on-demand plan,
 as well as networking information for the on-demand service.
+The Dedicated-VM plan has been marked as deprecated and will be removed in v2.0.
 For similar information for the Dedicated-VM and Shared-VM plans, see [Dedicated-VM and Shared-VM Service Offerings](./architecture-pp.html).
 
 

--- a/erc.html.md.erb
+++ b/erc.html.md.erb
@@ -12,6 +12,7 @@ and information for determining the product's fit for your enterprise's use case
 
 Dedicated-VM and Shared-VM plans are designed for datastore use cases.
 The Shared-VM plan is not recommended for production use.
+The Dedicated-VM plan as been marked as deprecated and will be completely removed in v2.0.
 On-Demand plans, introduced in Redis for PCF v1.8, are configured by default for
 cache use cases but can also be used as a datastore.
 
@@ -47,7 +48,7 @@ For descriptions of the three Redis for PCF service offerings, see:
 
 <p class="note"><strong>Note</strong>: As of Redis for PCF v1.11,
     the on-demand service is at feature parity with the dedicated-VM service.
-    The dedicated-VM service plan will be deprecated.
+    The dedicated-VM service plan will be deprecated and completely removed in v2.0.
     Pivotal recommends using the on-demand service plan.</p>
 
 ##<a id="checklist"></a> Enterprise-Readiness Checklist

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -80,7 +80,7 @@ Redis for PCF offers On-Demand, Dedicated-VM, and Shared-VM services.
 
 <p class="note"><strong>Note</strong>: As of Redis for PCF v1.11,
     the on-demand service is at feature parity with the dedicated-VM service.
-    The dedicated-VM service plan will be deprecated.
+    The dedicated-VM service plan will be deprecated and completely removed in v2.0.
     Pivotal recommends using the on-demand service plan.</p>
 
 For more information on the plans, see:

--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -362,7 +362,7 @@ VM's total system memory, you can do one of the following:
 
 <p class="note"><strong>Note</strong>: In Redis for PCF v1.11 and later,
     the on-demand service is at feature parity with the dedicated-VM service.
-    The dedicated-VM service plan will be deprecated.
+    The dedicated-VM service plan will be deprecated and completely removed in v2.0.
     Pivotal recommends using the on-demand service plan.
     For instructions on disabling these plans,
     see <a href="#disable-shared-dedicated">Disable Shared and Dedicated VM Plans</a> below.

--- a/monitoring.html.md.erb
+++ b/monitoring.html.md.erb
@@ -99,7 +99,7 @@ For a list of all other Redis metrics, see [Other Redis Metrics](#other-metrics)
 
 <p class="note"><strong>Note</strong>: As of Redis for PCF v1.11,
     the on-demand service is at feature parity with the dedicated-VM service.
-    The dedicated-VM service plan will be deprecated.
+    The dedicated-VM service plan will be deprecated and completely removed in v2.0.
     Pivotal recommends using the on-demand service plan.</p>
 
 <table>
@@ -135,7 +135,7 @@ For a list of all other Redis metrics, see [Other Redis Metrics](#other-metrics)
 
 <p class="note"><strong>Note</strong>: As of Redis for PCF v1.11,
     the on-demand service is at feature parity with the dedicated-VM service.
-    The dedicated-VM service plan will be deprecated.
+    The dedicated-VM service plan will be deprecated and completely removed in v2.0.
     Pivotal recommends using the on-demand service plan.</p>
 
 <table>

--- a/troubleshoot-instances.html.md.erb
+++ b/troubleshoot-instances.html.md.erb
@@ -221,7 +221,7 @@ If you have re-enabled the dedicated-vm plan, the service access is disabled aga
 Ops Manager or an operator runs these errands.
 
 <p class="note"><strong>Note</strong>: The service access has been restricted
-  because the dedicated-vm service plan will be removed in Redis for PCF v1.15.</p>
+  because the dedicated-vm service plan will be removed in Redis for PCF v2.0.</p>
 
 <br>
 <strong>Solution</strong><br>


### PR DESCRIPTION
- Part of the change to rename 1.15 to 2.0, I thought it best to clarify
the deprecation notice for Dedicated-VM instances. Explicitly mark dedicated-vm as deprecated and to be removed in 2.0

[#162412106]