### PR TITLE
[1.13] Update Docs to remove incorrect information about instance limits

### DIFF
--- a/architecture.html.md.erb
+++ b/architecture.html.md.erb
@@ -40,7 +40,6 @@ For each service plan, the operator can configure the **Plan name**, **Plan desc
 See [Configuration for On-Demand Service Plans](#config) for more information.
 * The default `maxmemory-policy` is `allkeys-lru` and can be updated for other cache policies.
 * The maximum number of instances is managed by a per-plan and global quota.
-The maximum number of instances cannot surpass 50.
 For information on setting quotas, see [Setting Limits for On-Demand Service Instances](./set-quotas.html).
 
 


### PR DESCRIPTION
Since 1.12 there's no longer a limit imposed by p-redis
[#162918612]