### PR TITLE
Add a link to critical service-backups error logs

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -548,6 +548,8 @@ To configure syslog forwarding, do the following:
 
 1.  Click **Save**.
 
+We recommend that operators setup alerts on critical logs as described in <a href="./monitoring.html#critical-logs"> Critical Logs </a><br/>
+
 ## <a id="stemcell"></a>Update Stemcell
 
 If required, do the following to update the stemcell for Redis for PCF:

--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -548,7 +548,7 @@ To configure syslog forwarding, do the following:
 
 1.  Click **Save**.
 
-We recommend that operators setup alerts on critical logs as described in <a href="./monitoring.html#critical-logs"> Critical Logs </a><br/>
+We recommend that operators set up alerts on critical logs as described in <a href="./monitoring.html#critical-logs"> Critical Logs </a><br/>
 
 ## <a id="stemcell"></a>Update Stemcell
 

--- a/monitoring.html.md.erb
+++ b/monitoring.html.md.erb
@@ -21,6 +21,13 @@ Metrics are emitted in the following format:
 origin:"p-redis" eventType:ValueMetric timestamp:1480084323333475533 deployment:"cf-redis" job:"cf-redis-broker" index:"{redacted}" ip:"10.0.1.49" valueMetric:&#60;name:"/p-redis/service-broker/dedicated_vm_plan/available_instances" value:4 unit:"" >
 </pre>
 
+## <a id="critical-logs"></a>Critical Logs
+Critical Logs are logs that should they ocurr, an operator should be notified to prevent further degradation of the Redis service.
+Examples include failed backups.
+
+* <a href="https://docs.pivotal.io/svc-sdk/service-backup/18-1/#troubleshooting">Critical Logs for Service-Backups</a>, these include log messages for failed backups, errored backups and failed to upload backups to destinations
+
+
 ## <a id="kpi"></a>Key Performance Indicators
 
 Key Performance Indicators (KPIs) for Redis for PCF are metrics that operators find most useful for monitoring their Redis service to ensure smooth operation.

--- a/monitoring.html.md.erb
+++ b/monitoring.html.md.erb
@@ -22,10 +22,10 @@ origin:"p-redis" eventType:ValueMetric timestamp:1480084323333475533 deployment:
 </pre>
 
 ## <a id="critical-logs"></a>Critical Logs
-Critical Logs are logs that should they ocurr, an operator should be notified to prevent further degradation of the Redis service.
-Examples include failed backups.
+An operator should be notified when a critical log occurs to prevent further degradation of the Redis service.
+One example of a critical log is a failed backup.
 
-* <a href="https://docs.pivotal.io/svc-sdk/service-backup/18-1/#troubleshooting">Critical Logs for Service-Backups</a>, these include log messages for failed backups, errored backups and failed to upload backups to destinations
+* <a href="https://docs.pivotal.io/svc-sdk/service-backup/18-1/#troubleshooting">Critical Logs for Service-Backups</a> include log messages for failed backups, backups with errors, and backups that failed to upload to destinations.
 
 
 ## <a id="kpi"></a>Key Performance Indicators


### PR DESCRIPTION
Following a recent incident, we decided to make clear that operators should alert on certain logs, specifically service-backup logs so they are aware when backups fail.


[#161798503]