### PR TITLE
Don't hardcode version numbers on floating links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ https://github.com/pivotal-cf/docs-book-redis
 
 The book repo uses these branches:
 
-* **Edge** builds from the **master** content branch (2.0 - previously known as 1.15 - available on staging here https://docs-pcf-staging.cfapps.io/redis/1-n/). Pipeline [here](https://concourse.run.pivotal.io/teams/cf-docs/pipelines/cf-services-edge?groups=redis-edge).
-* **Master** builds from the published content branches in this repo (1.12, 1.11, etc). Pipeline [here](https://concourse.run.pivotal.io/teams/cf-docs/pipelines/cf-services?groups=redis).
+* **Edge** builds from the **master** content branch are available on staging [here](https://docs-pcf-staging.cfapps.io/redis/1-n/). Pipeline [here](https://concourse.run.pivotal.io/teams/cf-docs/pipelines/cf-services-edge?groups=redis-edge).
+* **Master** builds from the published content branches in this repo (2.0, 1.14, 1.13, etc). Pipeline [here](https://concourse.run.pivotal.io/teams/cf-docs/pipelines/cf-services?groups=redis).
 
 ## Partials
 


### PR DESCRIPTION
Because master targets the next minor or major version, this often goes out of date and creates confusion.
Don't link master to a specific version to avoid confusion