### PR TITLE
Remove references to dedicated-vms and upgrade paths from 1.x to 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Use this section to specify spelling of special words for Redis for PCF:
 
 + on-demand plan
 + shared-VM plan
-+ dedicated-VM plan
 
 ## Pipelines
 

--- a/_breaking-change-dedicated-vms.html.md.erb
+++ b/_breaking-change-dedicated-vms.html.md.erb
@@ -1,6 +1,0 @@
-<p class="note breaking"><strong>Breaking Change:</strong> Dedicated VMs are absent from Redis for PCF v2.0.
-    As of Redis for PCF v1.11, the on-demand service is at feature parity with the dedicated-VM service.
-    Dedicated VMs are marked as deprecated in Redis for PCF v1.14.
-    Pivotal recommends that you migrate to the on-demand service plan or back up data before upgrading to Redis for PCF v2.0 
-    to prevent data loss in Redis deployments used as persistent storage. For information about migrating to on-demand service plans, see 
-    <a href="https://pvtl.force.com/s/article/Migrating-from-dedicated-vm-service-plans-to-on-demand-service-plans">Migrating from dedicated-vm service plans to on-demand service plans</a> in the Pivotal Support knowledge base.</p>

--- a/_note-dedicated-instances.html.md.erb
+++ b/_note-dedicated-instances.html.md.erb
@@ -1,4 +1,0 @@
-<p class="note"><strong>Note</strong>: As of Redis for PCF v1.11,
-    the on-demand service is at feature parity with the dedicated-VM service.
-    Dedicated-VMs are marked as deprecated in v1.14 and are removed in v2.0.
-    Pivotal recommends that you migrate to the on-demand service plan.</p>

--- a/_service-offerings.html.md.erb
+++ b/_service-offerings.html.md.erb
@@ -13,7 +13,3 @@ Redis for PCF v2.0 and later offers On-Demand and Shared-VM services.
   The Shared-VM instances are pre-provisioned by the operator with a fixed number
   of instances and memory size.
   App developers can then use one of these pre-provisioned instances.
-
-* **(Deprecated) Dedicated-VM Service**---Provides a dedicated VM running a Redis instance.
-  The dedicated-VM service is pre-provisioned by the operator with a fixed number
-  of VMs and memory size. App developers can then use one of those pre-provisioned VMs.

--- a/architecture-pp.html.md.erb
+++ b/architecture-pp.html.md.erb
@@ -81,7 +81,7 @@ Limitations of the `shared-vm` plan include:
 * Because the Shared-VM plan does not manage "noisy neighbor" problems, Pivotal does not recommend it for production apps.
 
 
-## <a id="lifecycle-dedicated-shared"></a>Lifecycle for Shared-VM Service Plan
+## <a id="lifecycle-shared"></a>Lifecycle for Shared-VM Service Plan
 
 Here is the lifecycle of Redis for PCF, from an operator installing the tile through an app developer using the service then an operator deleting the tile.
 

--- a/bbr-backup.html.md.erb
+++ b/bbr-backup.html.md.erb
@@ -16,7 +16,7 @@ For more information, see [Configuring Automated Service Backups](./auto-backup.
 [Comparison of the Available Backup Methods](./auto-backup.html#comparison).
 
 <p class="note"><strong>Note</strong>: Only on-demand Redis service instances have support for BBR,
-  for backup and restore of dedicated and shared instances see <a href="./auto-backup.html">Configuring Automated Backups for Redis for PCF</a>.</p>
+  for backup and restore of shared instances see <a href="./auto-backup.html">Configuring Automated Backups for Redis for PCF</a>.</p>
 
 
 ## <a id="prepare"></a>Prepare to Use BBR

--- a/erc.html.md.erb
+++ b/erc.html.md.erb
@@ -13,7 +13,7 @@ and information for determining the product's fit for your enterprise's use case
 On-Demand plans are configured by default for cache use cases but can also be used
 as a datastore.
 
-Dedicated-VM and Shared-VM plans are designed for datastore use cases.
+Shared-VM plans are designed for datastore use cases in testing or development environments.
 
 <p class="note"><strong>Note</strong>: The Shared-VM service should only be used for development and testing.
    Do not use for production.</p>
@@ -44,13 +44,6 @@ For descriptions of the Redis for PCF service offerings, see:
 
 * [On-Demand Service Offering](./architecture.html)
 * [Shared-VM Service Offering](./architecture-pp.html)
-
-<div class="note"><strong>Note:</strong>
-  <ul>
-    <li>The Shared-VM plan is not recommended for production use.</li>
-    <li>The Dedicated-VM plan is marked as deprecated and will be removed in v2.0.</li>
-    <li>If you have any dedicated-VM instances you must migrate to the on-demand service plan before upgrading to Redis for PCF v2.0. For information about migrating to on-demand service plans, see <a href="https://pvtl.force.com/s/article/Migrating-from-dedicated-vm-service-plans-to-on-demand-service-plans">Migrating from dedicated-vm service plans to on-demand service plans</a> in the Pivotal Support knowledge base.</li>
-</div>
 
 ##<a id="checklist"></a> Enterprise-Readiness Checklist
 

--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -89,7 +89,7 @@ The following ports and ranges are used in Redis for PCF:
 | 8202                  | TCP                          | Inbound to Cloud Foundry network, outbound from service broker and service instance networks* | Used by the Redis metron_agent to forward metrics to the Cloud Foundry Loggregator                                          |
 | 12350                 | TCP                          | Outbound from Cloud Foundry to the cf-redis-broker service broker network                       | (Only if using a cf-redis-broker) Access to the cf-redis-broker from the cloud controllers.                                 |
 | 12345                 | TCP                          | Outbound from Cloud Foundry to the on-demand service broker network                             | (Only if using an On-Demand service) For access to the on-demand service broker from the cloud controllers          |
-| 6379                  | TCP                          | Outbound from Cloud Foundry to any service instance networks (dedicated-node and on-demand)     | Access to all dedicated nodes and on-demand nodes from the Diego Cell and Diego Brain network(s)                            |
+| 6379                  | TCP                          | Outbound from Cloud Foundry to any service instance networks (on-demand)                       | Access to all on-demand nodes from the Diego Cell and Diego Brain network(s)                            |
 | 32768-61000           | TCP                          | Outbound from Cloud Foundry to the cf-redis-broker service broker network                       | From the Diego Cell and Diego Brain network(s) to the service broker VM. This is only required for the shared service plan. |
 | 80 or 443<br>(Typically) | http or https<br>respectively  | Outbound from any service instance networks                                                    | Access to the backup blobstore                                                                                             |
 | 8443<br>25555           | TCP                          | Outbound from any on-demand service broker network to the BOSH Director network                | For the on-demand service, the on-demand service broker needs to talk to the BOSH Director                                    |
@@ -392,17 +392,6 @@ The following are the default resource and IP requirements for Redis for PCF whe
   </tr>
   <tr>
     <td>Redis</td>
-    <td>Dedicated Node</td>
-    <td>5</td>
-    <td>2</td>
-    <td>1024</td>
-    <td>4096</td>
-    <td>4096</td>
-    <td>1</td>
-    <td>0</td>
-  </tr>
-  <tr>
-    <td>Redis</td>
     <td>Broker Registrar</td>
     <td>1</td>
     <td>1</td>
@@ -436,7 +425,7 @@ The following are the default resource and IP requirements for Redis for PCF whe
   </tr>
 </table>
 
-### <a id="disable-shared-dedicated"></a>Disable Shared VM Plans
+### <a id="disable-shared"></a>Disable Shared VM Plans
 
 You can disable Shared VM Plans by doing the following while configuring Redis tile:
 
@@ -455,7 +444,6 @@ You can disable Shared VM Plans by doing the following while configuring Redis t
   * **Resource Config**:<br>
     a. Decrease **Redis Broker** Persistent disk type to the smallest size available.<br>
     b. Decrease **Redis Broker** VM type to the smallest size available.<br>
-    c. Set **Dedicated Node** Instances to 0.<br>
     d. Click **Save**.<br>
 
 ### <a id="configurations"></a>Additional Redis Configurations

--- a/maintain.html.md.erb
+++ b/maintain.html.md.erb
@@ -52,14 +52,6 @@ Redis for PCF includes the errands listed below.
 
 * **Broker Registrar**---Registers the cf-redis-broker with PCF to offer the `p-redis` service,
   that is, the shared-VM plan.
-  The Broker Registrar errand also includes the Deprecate Dedicated-VM Plan errand.
-  It disables service access to the dedicated-VM plan for non-admin app developers.
-
-* **Deprecate Dedicated-VM Plan**---Disables service access to the dedicated-VM plan
-    for non-admin app developers.
-
-* **Cleanup Metadata if Dedicated-VM Plan Disabled**---Cleans up any metadata in PCF for any dedicated-VM service instances if zero dedicated
-    instances are provisioned. You can run this errand to clean up metadata after you have deleted all dedicated instances.
 
 * **Smoke Tests**---Runs lifecycle tests for shared-VM plans if these have been enabled and there is remaining quota available.
     The tests cover provisioning, binding, reading, writing, unbinding, and deprovisioning of service instances.
@@ -107,12 +99,6 @@ Then it might not be necessary to run all of the Redis for PCF tile's post-deplo
 
 - Required to run if the CF system domain is changed in the PAS tile.
 - Not necessary to run if the change only involves other tiles except PAS tile.
-
-#### Deprecate Dedicated-VM Plan Errand
-
-- Run this errand to prepare for deprecation of support for dedicated nodes.
-- Only needs to be run once to disable service access to the dedicated-VM plan for non-admin app developers.
-- Not needed if the Broker Registrar errand has been run.
 
 #### Register On-Demand Broker Errand
 

--- a/monitoring.html.md.erb
+++ b/monitoring.html.md.erb
@@ -18,7 +18,7 @@ The metrics polling interval defaults to 30 seconds. This can be changed by navi
 Metrics are emitted in the following format:
 
 <pre class=terminal>
-origin:"p-redis" eventType:ValueMetric timestamp:1480084323333475533 deployment:"cf-redis" job:"cf-redis-broker" index:"{redacted}" ip:"10.0.1.49" valueMetric:&#60;name:"/p-redis/service-broker/dedicated_vm_plan/available_instances" value:4 unit:"" >
+origin:"p-redis" eventType:ValueMetric timestamp:1480084323333475533 deployment:"cf-redis" job:"cf-redis-broker" index:"{redacted}" ip:"10.0.1.49" valueMetric:&#60;name:"/p-redis/service-broker/shared_vm_plan/available_instances" value:4 unit:"" >
 </pre>
 
 ## <a id="critical-logs"></a>Critical Logs

--- a/quickstart.html.md.erb
+++ b/quickstart.html.md.erb
@@ -185,12 +185,12 @@ app.get('/', function(request, response) {
 
 ### <a id="java-quickstart"></a> Quickstart Ruby App
 This is a basic ruby app with the capability to get and set keys in Redis and view configuration information.
-Here we use an instance of the dedicated_vm service, but any p-redis or p.redis instance works.
+Here we use an instance of the shared_vm service, but any p-redis or p.redis instance works.
 
 <pre class=terminal>
 $ git clone git@github.com:pivotal-cf/cf-redis-example-app.git ruby_redis_app
 $ cd ruby_redis_app
-$ cf create-service p-redis dedicated-vm redis_instance
+$ cf create-service p-redis shared-vm redis_instance
 $ cf push redis_example_app --no-start
 $ cf bind-service redis_example_app redis_instance
 $ cf start redis_example_app"

--- a/smoke-tests.html.md.erb
+++ b/smoke-tests.html.md.erb
@@ -29,11 +29,6 @@ and delete it after the tests finish. This security group has the following rule
 [
     {
       "protocol": "tcp",
-      "destination": "<dedicated node IP addresses>",
-      "ports": "6379" // Redis dedicated node port
-    },
-    {
-      "protocol": "tcp",
       "destination": "<broker IP address>",
       "ports": "32768-61000" // Ephemeral port range (assigned to shared-vm instances)
     }

--- a/troubleshooting.html.md.erb
+++ b/troubleshooting.html.md.erb
@@ -134,8 +134,6 @@ You can obtain information specific to the cf-redis broker as follows:
   * For shared-VMs, the redis processes are colocated with the CF-Redis broker.
     You can check these VMs using `ps aux | grep redis-server`.
   * Shared-VM data is stored in `/var/vcap/store/cf-redis-broker/redis-data`.
-  * A map of dedicated-VMs can be found in `/var/vcap/store/cf-redis-broker/statefile.json`.
-
 
 <a id="redis-cli"></a><h2>About the Redis CLI</h2>
 

--- a/upgrade.html.md.erb
+++ b/upgrade.html.md.erb
@@ -14,31 +14,6 @@ Before upgrading Redis for PCF, for compatibility information, see the
 
 ## <a id="upgrades"></a>Upgrade to Redis for PCF v2.0
 
-<%= partial 'breaking-change-dedicated-vms' %>
-
-This product enables a reliable upgrade experience between versions of the product
-deployed through Ops Manager.
-
-For information on the upgrade paths for each released version, see
-[Compatible Upgrade Paths](#upgrading) above.
-
-To upgrade Redis for PCF v2.0, do the following:
-
-1. Download the latest version of the product from [Pivotal Network](https://network.pivotal.io/products/p-redis).
-
-1. Upload the new `.pivotal` file to Ops Manager.
-
-1. If required, upload the stemcell associated with the update.
-
-1. Select the deprecation warning checkbox in the **WARNING - DEPRECATED INSTANCES** tab.
-This removes any dedicated-VM instances in your deployment.
-    <p class="note"> <strong>Note:</strong>
-      This checkbox is mandatory when upgrading to Redis for PCF v2.0.
-
-1. If required, update any new mandatory configuration parameters.
-
-1. Click **Apply changes**. The rest of the process is automated.
-
 During the upgrade each Redis instance experiences a small period of
 downtime as each instance is updated with the new software components.
 This downtime is because Redis instances are single VMs operating in a non

--- a/using.html.md.erb
+++ b/using.html.md.erb
@@ -352,7 +352,7 @@ Example `VCAP_SERVICES`
           },
           "label": "p-redis",
           "name": "redis",
-          "plan": "dedicated-vm",
+          "plan": "shared-vm",
           "provider": null,
           "syslog_drain_url": null,
           "tags": [


### PR DESCRIPTION
cc @edwardecook 

Clears instructions to migrate off deprecated Dedicated-VM plans.