### PR TITLE
Add documentation on originating service instance type for redis metrics

### DIFF
--- a/monitoring.html.md.erb
+++ b/monitoring.html.md.erb
@@ -137,6 +137,11 @@ For a list of all other Redis metrics, see [Other Redis Metrics](#other-metrics)
 
 ### <a id="Redis-KPIs"></a> Redis KPIs
 
+Service instance metrics for Shared-VM service instances have origin <code>p-redis</code> and have names
+pre-pended with <code>/p-redis/shared-vm/&lt;shared-instance-guid&gt;/</code>.
+
+Service instance metrics for On-Demand service instances have origin <code>p.redis</code>.
+
 #### <a id="persistent-disk-percent"></a> Percent of Persistent Disk Used
 
 <table>


### PR DESCRIPTION
Hi docs,

This PR adds documentation about the service instance type for Redis metrics, since shared-vm instances now also emit metrics.

Story: https://www.pivotaltracker.com/story/show/164134755

Thanks,
Mirah & @jimbo459 