### PR TITLE
Added release notes for tile_installer_client use for errands.

### DIFF
--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -32,6 +32,8 @@ For more information, see [BOSH HotSwaps](./upgrade.html#osh-hotswaps).
 For more information about Redis v5.0.3, see the
 [Redis 5.0 release notes](https://raw.githubusercontent.com/antirez/redis/5.0/00-RELEASENOTES).
 
+* All errands now use `tile_installer_client` for authentication, as opposed to `admin_credentials`.
+
 ### Resolved Issues
 
 This release fixes the following issues:


### PR DESCRIPTION
Errands no longer use `admin_credentials` users when they run, instead they use a `tile_installer_client`.

Tracker history here: https://www.pivotaltracker.com/story/show/164045278
[#164045278]

Signed-off-by: James Norman <jnorman@pivotal.io>