### PR TITLE
[Redis] Add missing step to transfer artefact to new service isntance

### DIFF
--- a/troubleshooting.html.md.erb
+++ b/troubleshooting.html.md.erb
@@ -425,6 +425,10 @@ To back up your data and create a new service instance, do the following:<br><br
         <pre>mkdir /var/vcap/store/MY-BACKUPS</pre>
       </li>
 
+      <li> Transfer the backup artefact to the new service instance, saving the RDB file in
+        <pre>/var/vcap/store/MY-BACKUPS/</pre>.
+      </li>
+
       <li>To verify the RDB file has not been corrupted, run the following command:
         <pre>md5sum RDB-FILE</pre>
         Where <code>RDB-FILE</code> is the path to your RDB file.


### PR DESCRIPTION
Hi docs team, 

We missed a step when writing the troubleshooting steps for an orphaned service instance where PCF knows about the instance but BOSH doesn't. 

Also, not sure if we asked to cherry-pick this (and the previous relevant PR, https://github.com/pivotal-cf/docs-redis/pull/344) back to older branches, but that would be much appreciated. 

Thanks so much.

Best,
@jimbo459 and Mirah