### PR TITLE
[2.0] Add warning to suggest restarting odb after 2.3->2.4 upgrade

### DIFF
--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -5,6 +5,11 @@ owner: London Services
 
 <strong><%= modified_date %></strong>
 
+<p class="note warning"><strong>Warning: </strong>
+  If you are upgrading PCF v2.3 to v2.4, you must run
+  <code>bosh -d MY-DEPLOYMENT restart redis-on-demand-broker</code> errand after upgrading.
+  Failure to do so causes compatibility issues with runtime CredHub.</p>
+
 ## <a id="201"></a> v2.0.1
 
 **Release Date: February 12, 2019**


### PR DESCRIPTION
This is related to https://www.pivotaltracker.com/story/show/164629852 following a discussion with services enablement.

cc @jplebre @kieron-pivotal @winnab 