### PR TITLE
[2.1] Configuring Shared-VMs via arbitrary params is not supported

### DIFF
--- a/architecture-pp.html.md.erb
+++ b/architecture-pp.html.md.erb
@@ -45,6 +45,7 @@ There is no way to configure shared plans to use a custom limit.
 
 + Replication and event notification are not configured.
 
+For this reason, Shared-VM does not support arbitrary parameters CLI commands to be used to configure service instances.
 
 #### <a id="notes-shared"></a> Operator Notes for the Shared-VM Plan
 

--- a/using.html.md.erb
+++ b/using.html.md.erb
@@ -257,6 +257,8 @@ App developers can customize the following parameters. See the <a href="https://
 
 ### <a id="customize-cli"></a> Customize an On-Demand Instance with the cf CLI
 
+<p class="note"><strong>Note</strong>: Arbitrary params are only supported for on-demand service instances. Arbitrary Params for shared-vms is not supported command.</p>
+
 You can customize an instance in two ways:
 
 * While creating the instance, run: <br>`cf create-service SERVICE PLAN NAME -c '{"PROPERTY":"SETTING"}'`


### PR DESCRIPTION
- Shared-VMs are not configurable, therefore we don't support arbitrary
params (e.g. `cf create-service MY-DB-SERVICE small-plan -c { paramkey:
paramvalue }`)

[#164298101]