### PR TITLE
Document firehose deprecation and RLP/Log-Cache recommendation

### DIFF
--- a/monitoring.html.md.erb
+++ b/monitoring.html.md.erb
@@ -5,7 +5,9 @@ owner: London Services
 
 <strong><%= modified_date %></strong>
 
-The [Loggregator Firehose](https://docs.pivotal.io/pivotalcf/loggregator/architecture.html#firehose) exposes Redis metrics. You can use third-party monitoring tools to consume Redis metrics to monitor Redis performance and health.
+Redis metrics are emitted through Loggregator via the [Reverse Log Proxy](https://github.com/cloudfoundry/loggregator/blob/master/docs/rlp_gateway.md) and [Log Cache](https://github.com/cloudfoundry/log-cache/blob/master/README.md). You can use third-party monitoring tools to consume Redis metrics to monitor Redis performance and health.
+
+<a id="firehose"></a>The [Loggregator Firehose](https://docs.pivotal.io/pivotalcf/loggregator/architecture.html#firehose) endpoint is being deprecated. 
 
 As an example of how to display KPIs and metrics, see the [CF Redis example dashboard](https://github.com/pivotal-cf/metrics-datadog-dashboard),
 which uses [Datadog](https://www.datadoghq.com). Pivotal does not endorse or provide support for any third-party solution.

--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -62,6 +62,11 @@ Do not select this choice as an errand run rule.
 For more information about this unexpected behavior, see
 [Errand Run Rules](https://docs.pivotal.io/tiledev/tile-errands.html#run-rules).
 
+### Upcoming Firehose Deprecation
+
+* The Loggregator firehose endpoint is scheduled for deprecation.
+For more details on how to replace the firehose endpoint, see the <a href="monitoring.html#firehose">monitoring section</a>.
+
 ### Compatibility
 
 The following components are compatible with this release:


### PR DESCRIPTION
Hi docs, 

This is to document the upcoming loggregator firehose deprecation and our recommendations about how to continue monitoring Redis metrics.

Best,
@jimbo459 and Mirah