### PR TITLE
Document service backup failure with stemcell 170.30+ as known issue.

### DIFF
--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -32,6 +32,8 @@ Do not select this option.
 For more information about this unexpected behavior, see
 [Errand Run Rules](https://docs.pivotal.io/tiledev/tile-errands.html#run-rules).
 
+* Service backups fail to upload backups when running against stemcell version 170.30+
+
 ### Compatibility
 
 The following components are compatible with this release:
@@ -125,6 +127,8 @@ This is inconsistent with other services.
 Do not select this choice as an errand run rule.
 For more information about this unexpected behavior, see
 [Errand Run Rules](https://docs.pivotal.io/tiledev/tile-errands.html#run-rules).
+
+* Service backups fail to upload backups when running against stemcell version 170.30+
 
 ### Compatibility
 


### PR DESCRIPTION
Hi docs,

We've added a known issue to our release notes for regarding an incompatibility between service-backups and certain stemcell versions.

For #164930374

Best!
@jimbo459 and Mirah