### PR TITLE
Document service backup bump to fix scp issue

### DIFF
--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -55,6 +55,8 @@ These instances now get upgraded.
 
 * When a shared service instance was missing a PID file, error messages and logs did not include this information.
 
+* Service Backups have been upgraded to version 18.2, which contains a fix for an issue where up-to-date versions of scp no longer support path '.'
+
 ### Known Issues
 
 This release has the following issues:


### PR DESCRIPTION
Adding documentation of service backups bump for 2.1. Part of https://www.pivotaltracker.com/story/show/164930374