### PR TITLE
Updates compatability matrix for 2.1.0.

### DIFF
--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -85,31 +85,31 @@ The following components are compatible with this release:
 </tr>
 <tr>
     <td>Stemcell</td>
-    <td>170.x</td>
+    <td>250.x</td>
 </tr>
 <tr>
     <td>PCF<sup></sup></td>
-    <td>v2.3.x and v2.4.x</td>
+    <td>v2.4.x and v2.5.x</td>
 </tr>
 <tr>
     <td>cf-redis-release</td>
-    <td>v434.0.27</td>
+    <td>v434.2.7</td>
 </tr>
 <tr>
     <td>on-demand-service-broker</td>
-    <td>v0.25.0</td>
+    <td>v0.26.1</td>
 </tr>
 <tr>
     <td>routing</td>
-    <td>v0.184.0</td>
+    <td>v0.188.0</td>
 </tr>
 <tr>
     <td>service-metrics</td>
-    <td>v1.9.0</td>
+    <td>v1.10.0</td>
 </tr>
 <tr>
     <td>service-backup</td>
-    <td>v18.1.16</td>
+    <td>v18.2.0</td>
 </tr>
 <tr>
     <td>syslog</td>
@@ -117,11 +117,11 @@ The following components are compatible with this release:
 </tr>
 <tr>
     <td>loggregator-agent</td>
-    <td>v3.2</td>
+    <td>v3.9</td>
 </tr>
 <tr>
     <td>bpm</td>
-    <td>v1.0.0</td>
+    <td>v1.0.3</td>
 </tr>
 <tr>
     <td>Redis OSS</td>


### PR DESCRIPTION
Finalising release notes for the 2.1.0 release, this is still currently only available to user groups as we are pending our OSL. Could we spin out a 2.1 branch as soon as is convenient (but still wait to publish it on the OSL) as we've done previously.

For https://www.pivotaltracker.com/story/show/164330743

cc @lassebe 