### PR TITLE
Release notes for 2.1.1

### DIFF
--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -9,7 +9,7 @@ owner: London Services
 
 <%= partial "warning-azure-outbound-internet-access" %>
 
-## <a id="210"></a> v2.1.0
+## <a id="210"></a> v2.1.1
 
 **Release Date: MM DD, 2019**
 
@@ -58,6 +58,8 @@ These instances now get upgraded.
 * Service Backups have been upgraded to version 18.2, which contains a fix for an issue where up-to-date versions of Secure Copy Protocol (SCP) no longer support path '.'
 
 * Metrics emitted from cf-redis-broker did not reach the Loggregator Firehose.
+
+* The AWS secret access key for S3 backups was not marked as a secret, and as such was not masked. We advise that you update these keys.
 
 
 ### Known Issues


### PR DESCRIPTION
Hi Docs, 

We've had to pull 2.1.0 and have now created 2.1.1. This is still currently only available to user groups as we are pending our OSL. Could we spin out a 2.1 branch as soon as is convenient (but still wait to publish it on the OSL) as we've done previously.

For https://www.pivotaltracker.com/story/show/164330743

James
cc @lassebe