### PR TITLE
Add warning to check if apps require lua scripting to be enabled

### DIFF
--- a/appdevs.html.md.erb
+++ b/appdevs.html.md.erb
@@ -46,6 +46,7 @@ repository in GitHub.
 
 <p class="note warning"><strong>Warning</strong>:
   The Steeltoe connector for Redis requires Redis for PCF to support Lua scripting.
+  Please check whether the language you are using requires Lua scripting. If it does, please contact your operator.
   By default, Lua scripting is disabled for Redis for PCF, but a PCF operator can
   change the setting to enable it by selecting the <strong>Lua Scripting</strong> checkbox in each service plan's <strong><a href="./installing.html#on-demand-plan-config">On-Demand Plan</a></strong> configuration pane.
 </p>

--- a/architecture-pp.html.md.erb
+++ b/architecture-pp.html.md.erb
@@ -82,6 +82,7 @@ For this reason, Shared-VM plans do not support using CLI commands with arbitrar
 
 <p class="note warning"><strong>Warning</strong>:
   The Steeltoe connector for Redis requires Redis for PCF to support Lua scripting.
+  Please check if any of your apps require Lua scripting.
   By default, Lua scripting is disabled for Redis for PCF, but a PCF operator can
   change the setting to enable it by selecting the <strong>Lua Scripting</strong> checkbox in the <strong><a href="./installing.html#shared-vm-config">Shared-VM Plan</a></strong> configuration pane.
 </p>

--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -252,10 +252,10 @@ For each on-demand service plan, configure it as follows:
             <td>**Lua Scripting**</td>
             <td>Enable or disable Lua scripting as needed.<br />
                 Redis for PCF disables Lua scripting by default.
-                Pivotal recommends keeping Lua scripting disabled unless developers are running Steeltoe apps that use Redis.<br />
-                To work with Steeltoe apps, Redis for PCF must have Lua scripting enabled.
-                This setting supports the <code>IDistributedCache</code> interface
-                used by the Redis Steeltoe connector.
+                Pivotal recommends keeping Lua scripting disabled unless developers are running apps that make use of Lua scripting.<br />
+                As an example, .Net Steeltoe apps require Lua scripting to be enabled. 
+                Please check whether the language your apps are using requires Lua scripting.
+
             </td>
           </tr>
     </table>


### PR DESCRIPTION
Hi Docs!

Improved warning for operators / app devs to check if their apps require Lua scripting to be enabled.

This can be merged straight away, and is not reliant on an upcoming release.

Tracker story ID:[#166632357]

Thanks @jimbo459 & @jplebre