### PR TITLE
Document TLS in enterprise readiness criteria.

### DIFF
--- a/erc.html.md.erb
+++ b/erc.html.md.erb
@@ -168,10 +168,11 @@ Review the following table to determine if <%= vars.product_name %> has the feat
   </tr>
   <tr><th colspan=2>Encryption</th><th>More Information</th></tr>
   <tr><td>Encrypted Communication in Transit</td><td><%= vars.product_name %> has been tested with the IPsec Add-on for PCF.
-          Beyond that <%= vars.product_name %> does not provide additional encryption on top of Redis.</td>
+          <%= vars.product_name %> provides optional in-flight TLS encryption when enabled.</td>
       <td>
         <a href="https://docs.pivotal.io/addon-ipsec/index.html">Securing Data in Transit with the IPsec add-on</a><br><br>
-        <a href="https://redis.io/topics/security">OS Redis Security</a>
+        <a href="https://redis.io/topics/security">OS Redis Security</a><br><br>
+        <a href="./architecture.html#diagram1">Secure Traffic Architecture Diagram</a>
       </td></tr>
 
 </table>


### PR DESCRIPTION
Hi docs, 

Can you please cherry-pick this back to 2.2

Thanks!