### PR TITLE
Include TLS port in ASG and change dedicated to On-Demand.

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -665,13 +665,19 @@ App containers that use instances of the <%= vars.product_name %> service requir
 <td><code>ASSIGNED_NETWORK</code></td>
 <td>32768-61000</td>
 <td>tcp</td>
-<td>Enable application to access shared vm service instance</td>
+<td>Enable application to access Shared-VM Service Instance</td>
 </tr>
 <tr>
 <td><code>ASSIGNED_NETWORK</code></td>
 <td>6379</td>
 <td>tcp</td>
-<td>Enable application to access dedicated vm service instance</td>
+<td>Enable application to access On-Demand Service Instance</td>
+</tr>
+<tr>
+<td><code>ASSIGNED_NETWORK</code></td>
+<td>16379</td>
+<td>tcp</td>
+<td>Enable application TLS encrypted access to On-Demand Service Instance</td>
 </tr>
 </tbody></table>
 
@@ -683,7 +689,7 @@ to give all started apps access, bind to the `default-running` ASG set and resta
   {
     "protocol": "tcp",
     "destination": "ASSIGNED_NETWORK",
-    "ports": "6379"
+    "ports": "6379,16379"
   }
 ]
 ```


### PR DESCRIPTION
Hi docs,

This is to update the ASG to include the ASG port. Can you please cherry-pick this back to 2.2

Also, I've noticed that the wording was previously Dedicated, which should have been On-Demand. Can you fix that back through all the available versions?

Thanks!
Mirah