### PR TITLE
Remove confusing "in GitHub."

### DIFF
--- a/monitoring.html.md.erb
+++ b/monitoring.html.md.erb
@@ -7,7 +7,7 @@ owner: London Services
 
 ## <a id="loggregator"></a>Loggregator
 
-Redis metrics are emitted through Loggregator via the [Reverse Log Proxy](https://github.com/cloudfoundry/loggregator/blob/master/docs/rlp_gateway.md) and [Log Cache](https://github.com/cloudfoundry/log-cache/blob/master/README.md) in GitHub. You can use third-party monitoring tools to consume Redis metrics to monitor Redis performance and health.
+Redis metrics are emitted through Loggregator via the [Reverse Log Proxy](https://github.com/cloudfoundry/loggregator/blob/master/docs/rlp_gateway.md) and [Log Cache](https://github.com/cloudfoundry/log-cache/blob/master/README.md). You can use third-party monitoring tools to consume Redis metrics to monitor Redis performance and health.
 <a id="firehose"></a>The [Loggregator Firehose](https://docs.pivotal.io/pivotalcf/loggregator/architecture.html#firehose) endpoint is being deprecated.
 
 As an example of how to display KPIs and metrics without the Firehose, see the


### PR DESCRIPTION
Hi docs,

Can you please cherry-pick this back through 2.1

Also, I've noticed that the partial ../../redis/partials/services-tshoot/tshoot-err-missing-logs is incorrect and still refers to the firehose, which has been deprecated. Is there a way to update this partial to refer instead to the cf log-stream plugin? 

Thanks!