### PR TITLE
Document smoke test bug.

### DIFF
--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -21,7 +21,7 @@ owner: London Services
 
 ### Known Issues
 
-There are no known issues for this release.
+* Smoke tests fail when run in environments with ruby buildpack version 1.8.11 or later.
 
 ### Compatibility
 
@@ -107,7 +107,7 @@ This release has the following fixes:
 
 ### Known Issues
 
-There are no known issues for this release.
+* Smoke tests fail when run in environments with ruby buildpack version 1.8.11 or later.
 
 
 ### Compatibility


### PR DESCRIPTION
Hi docs, 

This is to document a known issue with the smoke tests failing on environments with ruby buildpack 1.8.11+

Best,