### PR TITLE
Add 2.10 compatibility for 2.3.3 version.

### DIFF
--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -40,7 +40,7 @@ The following components are compatible with this release:
 </tr>
 <tr>
     <td><%= vars.app_runtime_full %><sup></sup></td>
-    <td>2.7.x, 2.8.x, and 2.9.x</td>
+    <td>2.7.x, 2.8.x, 2.9.x and 2.10.x</td>
 </tr>
 <tr>
     <td>shared-redis-release</td>


### PR DESCRIPTION
Hi Team,

We have recently tested the 2.10 compatibility for 2.3.3 recently and updated the docs. Please review it and let us know if you need anything. More info on this slack thread: https://pivotal.slack.com/archives/C84KAKS1Z/p1596241343087900 

Thanks,
Redis Team
