### PR TITLE
Add 2.10 compatibility for latest redis 1.14 latest.

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -33,11 +33,11 @@ This documentation:
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>2.3 and 2.4</td>
+        <td>2.3, 2.4 and 2.10</td>
     </tr>
     <tr>
         <td>Compatible Pivotal Application Service (PAS) version(s)</td>
-        <td> 2.3 and 2.4</td>
+        <td> 2.3, 2.4 and 2.10</td>
     </tr>
     <tr>
         <td>IaaS support</td>

--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -43,6 +43,8 @@ Do not select this choice as an errand run rule.
 For more information about this unexpected behavior, see
 [Errand Run Rules](https://docs.pivotal.io/tiledev/tile-errands.html#run-rules).
 
+* Smoke tests fail when run in environments with Ruby buildpack v1.8.11 or later.
+
 ### <a id="compat1147"></a> Compatibility
 
 The following components are compatible with this release:
@@ -58,7 +60,7 @@ The following components are compatible with this release:
 </tr>
 <tr>
     <td>PCF</td>
-    <td>2.3.x and 2.4.x</td>
+    <td>2.3.x, 2.4.x and 2.10.x</td>
 </tr>
 <tr>
     <td>cf-redis-release</td>


### PR DESCRIPTION
Hi Team,

We have recently been asked for some 2.10 compatibility testing for the older versions of Redis. More info is on this slack thread: https://pivotal.slack.com/archives/C0XND5Q9G/p1597256004158200 

Thanks,
Redis Team