### PR TITLE
Add 2.10 ops man compatibility  to redis 2.0 latest.

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -34,11 +34,11 @@ Redis service instances, and bind an app.
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>2.3, 2.4, and 2.5</td>
+        <td>2.3, 2.4, 2.5 and 2.10</td>
     </tr>
     <tr>
         <td>Compatible Pivotal Application Service (PAS) version(s)</td>
-        <td>2.3, 2.4 and 2.5</td>
+        <td>2.3, 2.4, 2.5 and 2.10</td>
     </tr>
     <tr>
         <td>IaaS support</td>

--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -49,6 +49,8 @@ This release has the following issue:
 Do not select this choice as an errand run rule.
 For more information about errand run rules, see [Errand Run Rules](https://docs.pivotal.io/tiledev/tile-errands.html#run-rules).
 
+* Smoke tests fail when run in environments with Ruby buildpack v1.8.11 or later.
+
 ### Compatibility
 
 The following components are compatible with this release:
@@ -64,7 +66,7 @@ The following components are compatible with this release:
 </tr>
 <tr>
     <td>PCF<sup></sup></td>
-    <td>2.3.x, 2.4.x, and 2.5.x</td>
+    <td>2.3.x, 2.4.x, 2.5.x and 2.10.x</td>
 </tr>
 <tr>
     <td>shared-redis-release</td>


### PR DESCRIPTION
Hi Team,

We have recently been asked for some 2.10 compatibility testing for the older versions of Redis. More info is on this slack thread: https://pivotal.slack.com/archives/C0XND5Q9G/p1597256004158200 

Thanks,
Redis Team
