### PR TITLE
 Add 2.10 ops man compatibility to redis 2.1 latest.

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -34,11 +34,11 @@ Redis service instances, and bind an app.
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>2.4, 2.5, and 2.6</td>
+        <td>2.4, 2.5, 2.6 and 2.10</td>
     </tr>
     <tr>
         <td>Compatible Pivotal Application Service (PAS) version(s)</td>
-        <td>2.4, 2.5, and 2.6</td>
+        <td>2.4, 2.5, 2.6 and 2.10</td>
     </tr>
     <tr>
         <td>IaaS support</td>

--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -44,7 +44,7 @@ The following components are compatible with this release:
 </tr>
 <tr>
     <td>PCF<sup></sup></td>
-    <td>2.4.x, 2.5.x and 2.6.x</td>
+    <td>2.4.x, 2.5.x, 2.6.x and 2.10.x</td>
 </tr>
 <tr>
     <td>shared-redis-release</td>


### PR DESCRIPTION
Hi Team,

We have recently been asked for some 2.10 compatibility testing for the older versions of Redis. More info is on this slack thread: https://pivotal.slack.com/archives/C0XND5Q9G/p1597256004158200 

Thanks,
Redis Team
