### PR TITLE
Add known issue with on-demand-broker's TLS verification when using an external UAA

### DIFF
--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -42,7 +42,7 @@ This release has the following fix:
 
 ### Known Issues
 
-There are no known issues for this release.
+An issue with the On-demand-broker and TLS verification may cause service creation to fail when using an external UAA: the `upgrade-all-service-instances` errand may fail on the TLS handshake, and therefore the service creation.
 
 ### Compatibility
 


### PR DESCRIPTION
Which other branches should this be merged with (if any)?
I'll add the same known issue to Redis 2.3 docs