### PR TITLE
Update Redis 2.3 with TAS 2.11 compatibility

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -42,7 +42,7 @@ Redis service instances, and bind an app.
     </tr>
     <tr>
         <td>Compatible <%= vars.app_runtime_full %> version(s)</td>
-        <td>2.7, 2.8, 2.9, and 2.10</td>
+        <td>2.7, 2.8, 2.9, 2.10 and 2.11</td>
     </tr>
     <tr>
         <td>IaaS support</td>

--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -55,7 +55,7 @@ The following components are compatible with this release:
   </tr>
   <tr>
     <td>VMware Tanzu Application Service for VMs</td>
-    <td>2.7.x, 2.8.x, 2.9.x, and 2.10.x</td>
+    <td>2.7.x, 2.8.x, 2.9.x, 2.10.x and 2.11.x</td>
   </tr>
   <tr>
     <td>shared-redis-release</td>
@@ -124,7 +124,7 @@ The following components are compatible with this release:
 </tr>
 <tr>
     <td>VMware Tanzu Application Service for VMs</td>
-    <td>2.7.x, 2.8.x, 2.9.x, and 2.10.x</td>
+    <td>2.7.x, 2.8.x, 2.9.x, 2.10.x and 2.11.x</td>
 </tr>
 <tr>
     <td>shared-redis-release</td>


### PR DESCRIPTION

Hi team, 

This PR adds TAS 2.11 compatibility to the Redis 2.3 tile. This update has to be done once the TAS 2.11 is released. Let the Redis team know if you have any other questions.

Thanks,
Bala Kaza