### PR TITLE
Update Redis 2.4 with TAS 2.11 compatibility

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -38,7 +38,7 @@ Redis service instances, and bind an app.
     </tr>
     <tr>
         <td>Compatible <%= vars.app_runtime_full %> version(s)</td>
-        <td>2.9 and 2.10</td>
+        <td>2.9, 2.10 and 2.11</td>
     </tr>
     <tr>
         <td>IaaS support</td>

--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -64,8 +64,8 @@ The following components are compatible with this release:
     <td>621.76</td>
 </tr>
 <tr>
-    <td><%= vars.ops_manager %></td>
-    <td>2.9 and 2.10</td>
+    <td><%= vars.platform_name %></td>
+    <td>2.9, 2.10 and 2.11</td>
 </tr>
 <tr>
     <td>shared-redis-release</td>

--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -64,7 +64,7 @@ The following components are compatible with this release:
     <td>621.76</td>
 </tr>
 <tr>
-    <td><%= vars.platform_name %></td>
+    <td><%= vars.app_runtime_full %></td>
     <td>2.9, 2.10 and 2.11</td>
 </tr>
 <tr>


### PR DESCRIPTION
Hi team,

This PR adds TAS 2.11 compatibility to the Redis 2.4 tile. This update has to be done once the TAS 2.11 is released. Let the Redis team know if you have any other questions.

Thanks,
Bala Kaza