### PR TITLE
Corrected the documentation in order to reflect the current design

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -683,9 +683,8 @@ You can disable shared-VM plans by doing the following while configuring the Red
     d. Leave all four on-demand errands On. <br>
     e. Click **Save**.<br><br>
   * **Resource Config**:<br>
-    a. Decrease **Redis Broker** Persistent disk type to the smallest size available.<br>
-    b. Decrease **Redis Broker** VM type to the smallest size available.<br>
-    c. Click **Save**.
+    a. For the **VM Type** and the **Persistent Disk Type** the only option is to leave the configuration the same or increase it. It is not possible to decrease the size.
+
 
 ## <a id="syslog"></a>Configure Syslog Forwarding
 


### PR DESCRIPTION
Change to the documentation to reflect the current design for the resource configs because the vm type and the disk type can't be decreased.