### PR TITLE
Update erc.html.md.erb

### DIFF
--- a/erc.html.md.erb
+++ b/erc.html.md.erb
@@ -30,14 +30,6 @@ Redis can be used in many different ways, including:
   using `ZRANGE`, `ZADD`, `ZREVRANGE`, `ZRANK`, `INCRBY`, and `GETSET`
 * Pub/Sub: Built in publish and subscribe operations: `PUBLISH`, `SUBSCRIBE`, and `UNSUBSCRIBE`
 
-## <a id="benchmarks"></a> SLO Benchmark
-
-The <%= vars.product_short %> team maintains a monthly Service Level Objective (SLO) of 99.95%
-uptime for the <%= vars.product_short %> offering on Pivotal Web Services.
-This is provided as a benchmark. SLOs for separate offerings of <%= vars.product_short %>
-vary based on variables such as infrastructure, networking, and
-relevant policies around security upgrades.
-
 ## <a id="offerings"></a> Service Offerings
 
 For descriptions of the service offerings for <%= vars.product_short %>, see:


### PR DESCRIPTION
As per a request from product (https://www.pivotaltracker.com/n/projects/1203638/stories/182623297), we don't need the SLO Benchmark section in our doc anymore, so we're removing it.