### PR TITLE
Metrics troubleshooting tip is version dependent

### DIFF
--- a/troubleshoot-instances.html.md.erb
+++ b/troubleshoot-instances.html.md.erb
@@ -100,7 +100,7 @@ The following errors occur in multiple services:
   </tr>
   <tr>
     <th>Cause</th>
-    <td>This might be because the Firehose is deactivated in the <%= vars.app_runtime_abbr %> tile.</td>
+    <td>Depending on your versions of <%= vars.app_runtime_abbr %> and <%= vars.product_short %> this might be because the Firehose is deactivated in the <%= vars.app_runtime_abbr %> tile.</td>
   </tr>
   <tr>
     <th style="vertical-align: top; padding-top: 1em;">Solution</th>


### PR DESCRIPTION
TAS no longer has an option to configure log cache nozzle ingestion in 3.0+.
