### PR TITLE
Metrics troubleshooting tip is version dependent (3.3)

### DIFF
--- a/troubleshoot-instances.html.md.erb
+++ b/troubleshoot-instances.html.md.erb
@@ -100,7 +100,7 @@ The following errors occur in multiple services:
   </tr>
   <tr>
     <th>Cause</th>
-    <td>This might be because the Firehose is deactivated in the <%= vars.app_runtime_abbr %> tile.</td>
+    <td>Depending on your versions of <%= vars.app_runtime_abbr %> and <%= vars.product_short %> this might be because the Firehose is deactivated in the <%= vars.app_runtime_abbr %> tile.</td>
   </tr>
   <tr>
     <th style="vertical-align: top; padding-top: 1em;">Solution</th>


### PR DESCRIPTION
TAS no longer has an option to configure log cache nozzle ingestion in 3.0+.

(cherry picked from commit 88559438797e5df8afa4285f6a97471c29cd5dfc)

